### PR TITLE
Add InterHuman forecasting P1 dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,15 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Local large assets and experiment outputs
+body_models/
+recognition_training/
+results/
+
+# Local tooling and downloaded artifacts
+.codex
+.codex/
+gh-local/
+*.pdf
+*.deb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@
 - `num_steps=1000, grad_accum_steps=16` 中等 smoke 已通过，耗时约 7 分钟，最终 checkpoint：`save/interhuman/p3_grad_accum_16_1000_smoke/model000001000.pt`。
 - 论文尺寸模型 smoke 已通过：`layers=8, latent_dim=512, lambda_orient/body/transl=1, grad_accum_steps=4, num_steps=100`。
 - 已修复 InterHuman H5 显式 translation loss 的 NaN：translation slot 使用最后一个 joint slot，而不是硬编码 index 55。
+- 论文 batch size 近似 smoke 已通过：`layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, effective_batch_size=64, num_steps=1000`，耗时 `1:16:09`，最终 checkpoint：`save/interhuman/paper_config_l8_d512_accum64_1000_smoke/model000001000.pt`。
 
 ## 下一步
 
-- 验证论文 batch size 近似口径：`layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, num_steps=1000`。
+- 进入更长 baseline：先试 `layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, num_steps=50000`，确认速度、checkpoint 和 loss 稳定性后再决定是否扩到更长。
+- 补 InterHuman 专用生成流程：DDIM-5，test-conditioned actor -> generated reactor。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,9 @@
 - InterHuman 训练当前固定 `num_workers=0`，原因是 PyTorch 1.7 多 worker 在提前按 `num_steps` 停止时会阻塞进程退出。
 - 已实现 P3 `--grad_accum_steps`；`num_steps` 表示 optimizer steps，`effective_batch_size=batch_size*world_size*grad_accum_steps`。
 - `grad_accum_steps=1` 和 `grad_accum_steps=2` 的短 smoke 已通过，checkpoint 可加载。
+- `num_steps=1000, grad_accum_steps=16` 中等 smoke 已通过，耗时约 7 分钟，最终 checkpoint：`save/interhuman/p3_grad_accum_16_1000_smoke/model000001000.pt`。
 
 ## 下一步
 
-- 跑单卡 baseline 前，先用 `num_steps=1000, grad_accum_steps=16` 做中等 smoke。
+- 进入单卡 baseline：先试 `layers=4, latent_dim=256, batch_size=1, grad_accum_steps=16 或 32, num_steps=50000`。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,9 +23,10 @@
 - 已修复 InterHuman H5 显式 translation loss 的 NaN：translation slot 使用最后一个 joint slot，而不是硬编码 index 55。
 - 论文 batch size 近似 smoke 已通过：`layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, effective_batch_size=64, num_steps=1000`，耗时 `1:16:09`，最终 checkpoint：`save/interhuman/paper_config_l8_d512_accum64_1000_smoke/model000001000.pt`。
 - 50K baseline 已启动：`layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, num_steps=50000, save_interval=5000`，保存目录：`save/interhuman/paper_config_l8_d512_accum64_50000_baseline`，launcher PID 记录在 `train.pid`。
+- 50K baseline 已通过早期 `step[100]` 检查：`loss=0.10378`，训练已进入 `epoch 2:532`。
 
 ## 下一步
 
-- 监控 50K baseline：先确认 `step[100]` loss 有限，再等待 `model000005000.pt` 和 `opt000005000.pt` 写出。
+- 监控 50K baseline：等待 `model000005000.pt` 和 `opt000005000.pt` 写出。
 - 补 InterHuman 专用生成流程：DDIM-5，test-conditioned actor -> generated reactor。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,10 @@
 - 论文尺寸模型 smoke 已通过：`layers=8, latent_dim=512, lambda_orient/body/transl=1, grad_accum_steps=4, num_steps=100`。
 - 已修复 InterHuman H5 显式 translation loss 的 NaN：translation slot 使用最后一个 joint slot，而不是硬编码 index 55。
 - 论文 batch size 近似 smoke 已通过：`layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, effective_batch_size=64, num_steps=1000`，耗时 `1:16:09`，最终 checkpoint：`save/interhuman/paper_config_l8_d512_accum64_1000_smoke/model000001000.pt`。
+- 50K baseline 已启动：`layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, num_steps=50000, save_interval=5000`，保存目录：`save/interhuman/paper_config_l8_d512_accum64_50000_baseline`，launcher PID 记录在 `train.pid`。
 
 ## 下一步
 
-- 进入更长 baseline：先试 `layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, num_steps=50000`，确认速度、checkpoint 和 loss 稳定性后再决定是否扩到更长。
+- 监控 50K baseline：先确认 `step[100]` loss 有限，再等待 `model000005000.pt` 和 `opt000005000.pt` 写出。
 - 补 InterHuman 专用生成流程：DDIM-5，test-conditioned actor -> generated reactor。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,38 @@
 - 监控 50K baseline：等待 `model000005000.pt` 和 `opt000005000.pt` 写出。
 - 补 InterHuman 专用生成流程：DDIM-5，test-conditioned actor -> generated reactor。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。
+
+## 2026-06-03 论文目标（已正式锁定）
+
+- 当前更合适的论文主线不是继续追 ReGenNet Table 4 完整复现，而是转为 `Interaction-aware joint forecasting of two-person human motion from partial observations`。
+- 中文表述：基于部分观测的交互感知双人动作联合未来预测。
+- 第一阶段建议锁定 InterHuman：固定 150 帧窗口，前 30 帧作为观测，联合预测后 120 帧双人动作。
+- `前 20% / 后 80%` 应作用在固定窗口上，不应直接作用在 InterHuman 原始全长序列上；过短序列第一阶段过滤，不用 padding 伪造未来。
+- 核心创新应是 relation-aware joint predictor，从可观测的双人相对位置、速度、朝向和关节距离中学习交互关系。
+- 必须比较 repeat/zero-velocity、independent predictor、concat no-relation predictor 和 relation-aware predictor。
+- 关键指标除 MSE / rotation MSE / translation MSE 外，还需要 relative root distance error、relative orientation error、inter-person distance consistency 和 long-horizon error。
+- ReGenNet InterHuman 50K baseline 定位调整为历史 backbone / 生成式 baseline / 工程资产，不再作为最终论文任务本身。
+- 上下文草案见 `docs/ai/context/20260603-155738-paper-final-goal-draft.md`。
+- 2026-06-03 已按用户要求停止当前 ReGenNet 50K baseline 长跑进程；最后可用 checkpoint 为 `save/interhuman/paper_config_l8_d512_accum64_50000_baseline/model000020000.pt`。
+- 正式实现设计见 `docs/ai/context/20260603-160713-forecasting-final-goal-design.md`。
+- P1-P6 完整路线图见 `docs/ai/context/20260603-161803-forecasting-p1-p6-roadmap.md`；后续每个阶段完成时必须新建阶段记录并引用该路线图。
+- 已用 `$academic-paper` 审阅 P1-P6 路线图：工程可行性中高，论文主张有条件成立；P5 主表应至少 3 seed 并报告 mean/std，P3/P4 必须记录参数量、训练预算和 seed；审阅记录见 `docs/ai/context/20260603-182845-forecasting-roadmap-feasibility-review.md`。
+- 已用 `using-superpowers` 整理 P1-P6 完整工程设计 contract，新增文件 `docs/ai/context/20260603-184214-forecasting-p1-p6-complete-design.md`；后续实现必须从 P1 开始，并按该文档的 CLI、文件职责、metrics、验收和阶段记录要求执行。
+- 已梳理 ReGenNet 三套数据集用法：当前项目中 NTU120-AS/Chi3D-AS 可走原论文 `Feeder -> ccollate -> CMDM -> ST-GCN eval` 路径；InterHuman-AS 是后补 SMPL H5 reproduction，可训练但缺论文 Table 4 evaluator/checkpoint；记录见 `docs/ai/context/20260603-185018-three-datasets-usage-review.md`。
+- InterHuman 第一阶段完成后，NTU120-AS 建议作为 action-conditioned forecasting / SMPL-X 规整大样本扩展，Chi3D-AS 建议作为高质量小样本 SMPL-X 泛化或 qualitative 补充；不要把三套数据集直接合并作为第一阶段训练集，记录见 `docs/ai/context/20260603-185530-ntu-chi3d-after-interhuman-plan.md`。
+- 最终正式设计文档已锁定为 `docs/ai/context/20260603-190003-forecasting-final-official-design.md`；后续实现、验收、阶段记录和论文结果解释以该文档为准。
+- 下一阶段从 P1 开始：新增 InterHuman forecasting dataset、active vector extract/restore、150 帧窗口裁剪、normalizer 和 shape/finite smoke。
+- P1/P2 完成前不要先做 relation-aware model；必须先让 repeat baseline evaluator 和 metrics 闭环。
+- 已新建 P1 计划文档：`docs/ai/context/20260603-190529-forecasting-p1-plan.md`。
+- P1 实现允许新增 `eval/eval_forecasting.py --mode dataset_smoke` 作为验收入口，但只做 dataset/normalizer smoke；P2 再扩展 metrics、repeat 和 checkpoint evaluation。
+- Forecasting P1 已完成，结果记录见 `docs/ai/context/20260603-191712-forecasting-p1-dataset-result.md`。
+- P1 新增实现：`utils/forecasting_motion.py`、`data_loaders/forecasting/interhuman.py`、`data_loaders/forecasting/tensors.py`、`eval/eval_forecasting.py`。
+- P1 smoke 已通过：train/val/test 可用样本为 `2910/226/508`，batch shape 为 `obs=[4,30,2,147]`、`target=[4,120,2,147]`，active roundtrip 误差 `0.0`，normalizer roundtrip 误差 `1.1920928955078125e-07`。
+- P1 normalizer 已生成：`save/forecasting/interhuman/p1_dataset_smoke/normalizer.pt` 和 `normalizer.json`；统计使用 train-only `T>=150` 序列共 `2910` 条、`1481944` 帧。
+- 下一步进入 P2：实现 original-scale metrics 和 repeat baseline evaluator；不得重新定义 P1 数据协议。
+
+## 2026-06-03 Skill 安装
+
+- 已安装 `Imbad0202/academic-research-skills` 仓库中的 4 个本地 Codex skills：`academic-pipeline`、`deep-research`、`academic-paper`、`academic-paper-reviewer`。
+- 安装位置为 `/home/rpartx3080/.codex/skills/`；后续会话需要重启 Codex 才能加载。
+- 安装记录见 `docs/ai/context/20260603-161246-academic-research-skills-install.md`。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# ReGenNet AI 上下文记忆
+
+## InterHuman-AS Table 4
+
+- Table 4 主指标是 `FID / Acc. / Div. / Multimod.`，不是 `R Precision / MM Dist`。
+- Table 4 主路径应使用 ST-GCN recognition feature evaluator；text-motion evaluator 只作为后续扩展。
+- 当前本地 InterHuman 数据没有 text/caption 目录，也没有 InterHuman recognition checkpoint。
+- 当前实现先走 SMPL reproduction attempt；若要精确对齐论文的 SMPL-X 口径，需要单独补 SMPL-X 转换或确认官方 evaluator 口径。
+
+## 已完成进度
+
+- 已新增 InterHuman-AS H5 预处理脚本：`preprocess/interhuman_as.py`。
+- 已生成冻结 H5：`dataset/interhuman/smpl/conditioned/interhuman_{train,val,test}.h5`。
+- 已为 `data_loaders/a2m/interhuman.py` 增加 H5 读取路径，同时保留在线 `.pkl` loader。
+- H5 输出与在线 loader 抽样对齐，最大误差为 0。
+- H5 loader 最小训练 smoke 已通过。
+
+## 下一步
+
+- 先跑 1000 step H5 full smoke。
+- 再实现 `--grad_accum_steps`。
+- P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@
 - 已为 `data_loaders/a2m/interhuman.py` 增加 H5 读取路径，同时保留在线 `.pkl` loader。
 - H5 输出与在线 loader 抽样对齐，最大误差为 0。
 - H5 loader 最小训练 smoke 已通过。
+- H5 full smoke 已通过：`save/interhuman/h5_full_1000_smoke_noworkers/model000001000.pt`。
+- InterHuman 训练当前固定 `num_workers=0`，原因是 PyTorch 1.7 多 worker 在提前按 `num_steps` 停止时会阻塞进程退出。
 
 ## 下一步
 
-- 先跑 1000 step H5 full smoke。
-- 再实现 `--grad_accum_steps`。
+- 实现 `--grad_accum_steps`。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,10 @@
 - H5 loader 最小训练 smoke 已通过。
 - H5 full smoke 已通过：`save/interhuman/h5_full_1000_smoke_noworkers/model000001000.pt`。
 - InterHuman 训练当前固定 `num_workers=0`，原因是 PyTorch 1.7 多 worker 在提前按 `num_steps` 停止时会阻塞进程退出。
+- 已实现 P3 `--grad_accum_steps`；`num_steps` 表示 optimizer steps，`effective_batch_size=batch_size*world_size*grad_accum_steps`。
+- `grad_accum_steps=1` 和 `grad_accum_steps=2` 的短 smoke 已通过，checkpoint 可加载。
 
 ## 下一步
 
-- 实现 `--grad_accum_steps`。
+- 跑单卡 baseline 前，先用 `num_steps=1000, grad_accum_steps=16` 做中等 smoke。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,10 @@
 - 已实现 P3 `--grad_accum_steps`；`num_steps` 表示 optimizer steps，`effective_batch_size=batch_size*world_size*grad_accum_steps`。
 - `grad_accum_steps=1` 和 `grad_accum_steps=2` 的短 smoke 已通过，checkpoint 可加载。
 - `num_steps=1000, grad_accum_steps=16` 中等 smoke 已通过，耗时约 7 分钟，最终 checkpoint：`save/interhuman/p3_grad_accum_16_1000_smoke/model000001000.pt`。
+- 论文尺寸模型 smoke 已通过：`layers=8, latent_dim=512, lambda_orient/body/transl=1, grad_accum_steps=4, num_steps=100`。
+- 已修复 InterHuman H5 显式 translation loss 的 NaN：translation slot 使用最后一个 joint slot，而不是硬编码 index 55。
 
 ## 下一步
 
-- 进入单卡 baseline：先试 `layers=4, latent_dim=256, batch_size=1, grad_accum_steps=16 或 32, num_steps=50000`。
+- 验证论文 batch size 近似口径：`layers=8, latent_dim=512, batch_size=1, grad_accum_steps=64, num_steps=1000`。
 - P5 前必须确认 InterHuman 类别标签来源和 recognition checkpoint 路线。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,196 @@
+# ReGenNet：面向人体动作-反应合成
+
+![](./assets/teaser.png)
+
+<p align="left">
+  <a href='https://arxiv.org/abs/2403.11882'>
+    <img src='https://img.shields.io/badge/Arxiv-2403.11882-A42C25?style=flat&logo=arXiv&logoColor=A42C25'>
+  </a>
+  <a href='https://arxiv.org/pdf/2403.11882.pdf'>
+    <img src='https://img.shields.io/badge/Paper-PDF-yellow?style=flat&logo=arXiv&logoColor=yellow'>
+  </a>
+  <a href='https://liangxuy.github.io/ReGenNet/'>
+  <img src='https://img.shields.io/badge/Project-Page-pink?style=flat&logo=Google%20chrome&logoColor=pink'></a>
+  <a href="" target='_blank'>
+    <img src="https://visitor-badge.laobi.icu/badge?page_id=liangxuy.ReGenNet&left_color=gray&right_color=orange">
+  </a>
+</p>
+
+本仓库包含以下论文对应的代码内容：
+> ReGenNet: Towards Human Action-Reaction Synthesis <br>[Liang Xu](https://liangxuy.github.io/)<sup>1,2</sup>, [Yizhou Zhou](https://scholar.google.com/citations?user=dHBNmSkAAAAJ&hl=zh-CN)<sup>3</sup>, [Yichao Yan](https://daodaofr.github.io/)<sup>1</sup>,  [Xin Jin](http://home.ustc.edu.cn/~jinxustc/)<sup>2</sup>, Wenhan Zhu, [Fengyun Rao](https://scholar.google.com/citations?user=38dACd4AAAAJ&hl=en)<sup>3</sup>, [Xiaokang Yang](https://scholar.google.com/citations?user=yDEavdMAAAAJ&hl=zh-CN)<sup>1</sup>, [Wenjun Zeng](https://scholar.google.com/citations?user=_cUfvYQAAAAJ&hl=en)<sup>2</sup><br>
+> <sup>1</sup> 上海交通大学 <sup>2</sup> 东方理工高等研究院（宁波） <sup>3</sup> 腾讯微信
+
+
+## 更新
+- [2024.07.14] 发布训练代码、评估代码以及预训练模型。
+- [2024.03.18] 发布论文与项目主页。
+
+
+## 方法框架
+![](./assets/framework.png)
+
+
+## 安装
+1. 首先使用以下命令克隆仓库：
+    ```
+    git clone https://github.com/liangxuy/ReGenNet.git
+    cd ReGenNet
+    ```
+
+2. 配置运行环境
+    <details>
+      <summary>1. 使用以下命令创建 conda 环境：</summary>
+
+      * 安装 ffmpeg（如果尚未安装）
+        ```
+        sudo apt update
+        sudo apt install ffmpeg
+        ```
+      * 创建 conda 环境
+        ```
+        conda env create -f environment.yml
+        conda activate regennet
+        python -m spacy download en_core_web_sm
+        pip install git+https://github.com/openai/CLIP.git
+        ```
+      * 安装 mpi4py（多 GPU 训练时需要）
+        ```
+        sudo apt-get install libopenmpi-dev openmpi-bin
+        pip install mpi4py
+        ```
+    </details>
+
+    如果你希望自行构建 Docker 环境，我们也提供了一个 Dockerfile：`docker/Dockerfile`。
+
+3. 下载其他必需文件
+
+    * 你可以从 [Google Drive](https://drive.google.com/drive/folders/1UtIIB67cZyWAfaw1ZKYjerp_pEAk_XTc?usp=sharing) 下载预训练模型，并将其放到 `save` 文件夹下，以复现实验结果。
+
+    * 你需要从 [Google Drive](https://drive.google.com/drive/folders/1oi1LCNMz3bQoiOktUEeyZRVb6VXEFohP?usp=sharing) 下载动作识别模型，并将其放到 `recognition_training` 文件夹下，用于评估。
+
+    * 从 [SMPL 官网](https://smpl.is.tue.mpg.de/) 下载 SMPL 中性模型，从 [SMPL-X 官网](https://smpl-x.is.tue.mpg.de/) 下载 SMPL-X 模型，然后分别放到 `body_models/smpl` 和 `body_models/smplx`。为方便使用，我们也提供了一份备份文件，见 [这里](https://drive.google.com/drive/folders/1OSLli1j7EBk79tvWk0Ep_adbCM20k8ZV?usp=sharing)。
+
+## 数据准备
+
+### NTU RGB+D 120
+由于 NTU RGB+D 120 数据集的许可证不允许我们公开分发其数据和标注，因此我们无法公开发布处理后的 NTU RGB+D 120 数据集。如果你对处理后的数据感兴趣，请发送邮件联系我。
+
+### Chi3D
+
+你可以在 [这里](https://ci3d.imar.ro/download) 下载原始数据集，并在 [这里](https://drive.google.com/file/d/1OvdOGgH1JpVL7viTgPOKHzJSVRB3NczN/view?usp=sharing) 下载 actor-reactor 顺序标注。
+
+你也可以从 [Google Drive](https://drive.google.com/drive/folders/1wPStrZgZaOa42ilADZRvv-_U7gBNjQEr?usp=sharing) 下载处理后的数据集，并将其放到 `dataset/chi3d` 目录下。
+
+### InterHuman
+
+你可以在 [这里](https://tr3e.github.io/intergen-page/) 下载原始数据集，并在 [这里](https://drive.google.com/file/d/10nLfK4uYNblHUhFXKHZWIbFvnRr7G805/view?usp=sharing) 下载 actor-reactor 顺序标注，然后将它们放到 `dataset/interhuman` 目录下。
+
+
+## 训练
+我们提供了在 `NTU120-AS` 数据集上进行人体动作-反应合成的 `online` 和 `unconstrained` 设置下的训练脚本。你也可以通过自定义 `--arch`、`--unconstrained` 和 `--dataset` 来适配不同设置。
+
+* 单 GPU 训练：
+
+  ```
+  # NTU RGB+D 120 数据集
+  python -m train.train_mdm --setting cmdm --save_dir save/cmdm/ntu_smplx --dataset ntu --cond_mask_prob 0 --num_person 2 --layers 8 --num_frames 60 --arch online --overwrite --pose_rep rot6d --body_model smplx --data_path PATH/TO/xsub.train.h5 --train_platform_type TensorboardPlatform --vel_threshold 0.03 --unconstrained
+  ```
+
+  ```
+  # Chi3D 数据集
+  python -m train.train_mdm --setting cmdm --save_dir save/cmdm/chi3d_smplx --dataset chi3d --cond_mask_prob 0 --num_person 2 --layers 8 --num_frames 150 --arch online --overwrite --pose_rep rot6d --body_model smplx --data_path PATH/TO/chi3d_smplx_train.h5 --train_platform_type TensorboardPlatform --vel_threshold 0.01 --unconstrained
+  ```
+
+* 多 GPU 训练（示例使用 4 张 GPU）：
+
+  ```
+  mpiexec -n 4 --allow-run-as-root python -m train.train_mdm --setting cmdm --save_dir save/cmdm/ntu_smplx --dataset ntu --cond_mask_prob 0 --num_person 2 --layers 8 --num_frames 60 --arch online --overwrite --pose_rep rot6d --body_model smplx --data_path PATH/TO/xsub.train.h5 --train_platform_type TensorboardPlatform --vel_threshold 0.03 --unconstrained
+  ```
+
+
+## 评估
+关于动作识别模型，你可以：
+
+1. 直接从 [这里](https://drive.google.com/drive/folders/1oi1LCNMz3bQoiOktUEeyZRVb6VXEFohP?usp=sharing) 下载训练好的动作识别模型；
+
+2. 或者自行训练动作识别模型：
+
+    动作识别模型的训练代码基于 [ACTOR](https://github.com/Mathux/ACTOR) 仓库。
+    <details>
+      <summary>训练你自己的动作识别模型的命令：</summary>
+
+      ```python
+      cd actor-x;
+      # 训练前，你需要先设置好 `dataset` 和 `SMPL-X models` 目录
+      ### NTU RGB+D 120 ###
+      python -m src.train.train_stgcn --dataset ntu120_2p_smplx --pose_rep rot6d --num_epochs 100 --snapshot 10 --batch_size 64 --lr 0.0001 --num_frames 60 --sampling conseq --sampling_step 1 --glob --translation --folder recognition_training/ntu_smplx --datapath dataset/ntu120/smplx/conditioned/xsub.train.h5 --num_person 2 --body_model smplx
+
+      ### Chi3D ###
+      python -m src.train.train_stgcn --dataset chi3d --pose_rep rot6d --num_epochs 100 --snapshot 10 --batch_size 64 --lr 0.0001 --num_frames 150 --sampling conseq --sampling_step 1 --glob --translation --folder recognition_training/chi3d_smplx --datapath dataset/chi3d/smplx/conditioned/chi3d_smplx_train.h5 --num_person 2 --body_model smplx
+      ```
+    </details>
+
+下面的脚本将评估训练好的模型 `PATH/TO/model_XXXX.pt`，其中 `rec_model_path` 是动作识别模型路径。结果会写入 `PATH/TO/evaluation_results_XXXX_full.yaml`。我们使用 `ddim5` 来加速评估过程。
+
+```
+python -m eval.eval_cmdm --model PATH/TO/model_XXXX.pt --eval_mode full --rec_model_path PATH/TO/checkpoint_0100.pth.tar --use_ddim --timestep_respacing ddim5
+```
+
+如果你想生成带均值与置信区间的表格，可以使用以下脚本：
+
+```
+python -m eval.easy_table PATH/TO/evaluation_results_XXXX_full.yaml
+```
+
+## 动作生成与可视化
+
+1. 生成结果，结果将保存到 `results.npy`。
+
+    ```
+    python -m sample.cgenerate --model_path PATH/TO/model_XXXX.pt --action_file assets/action_names_XXX.txt --num_repetitions 10 --dataset ntu --body_model smplx --num_person 2 --pose_rep rot6d --data_path PATH/TO/xsub.test.h5 --output_dir XXX
+    ```
+
+2. 渲染结果
+
+    安装额外依赖：
+    ```
+    pip install trimesh
+    pip install pyrender
+    pip install imageio-ffmpeg
+    ```
+
+    ```
+    python -m render.crendermotion --data_path PATH/TO/results.npy --num_person 2 --setting cmdm --body_model smplx
+    ```
+
+## 待办事项
+- [x] 发布训练代码、评估代码与预训练模型。
+- [x] 发布标注结果。
+
+
+
+## 致谢
+
+感谢以下项目与贡献者，本仓库代码基于它们构建：
+
+[ACTOR](https://github.com/Mathux/ACTOR), [motion diffusion model](https://github.com/GuyTevet/motion-diffusion-model), [guided diffusion](https://github.com/openai/guided-diffusion), [text-to-motion](https://github.com/EricGuo5513/text-to-motion), [HumanML3D](https://github.com/EricGuo5513/HumanML3D)
+
+
+## 许可证
+本代码基于 [MIT LICENSE](https://github.com/liangxuy/ReGenNet/blob/main/LICENSE) 分发。
+
+请注意，本项目依赖其他库，包括 CLIP、SMPL、SMPL-X、PyTorch3D，并且使用的数据集也各自具有独立许可证，使用时必须同时遵守这些许可证要求。
+
+
+## 引用
+如果你觉得 ReGenNet 对你的研究有帮助，请引用我们的工作：
+
+```
+@inproceedings{xu2024regennet,
+  title={ReGenNet: Towards Human Action-Reaction Synthesis},
+  author={Xu, Liang and Zhou, Yizhou and Yan, Yichao and Jin, Xin and Zhu, Wenhan and Rao, Fengyun and Yang, Xiaokang and Zeng, Wenjun},
+  booktitle={CVPR},
+  pages={1759--1769},
+  year={2024}
+}
+```

--- a/data_loaders/a2m/interhuman.py
+++ b/data_loaders/a2m/interhuman.py
@@ -1,0 +1,236 @@
+import json
+import os
+import pickle
+import random
+from pathlib import Path
+
+import h5py
+import numpy as np
+import torch
+
+from .dataset import Dataset
+
+
+class InterHuman(Dataset):
+    def __init__(self, datapath, **kwargs):
+        self.data_path = datapath or "dataset/interhuman"
+        self.max_samples = kwargs.get("max_samples", -1)
+        super().__init__(**kwargs)
+        self._h5_handles = {}
+        self._h5_mode = self._is_h5_path(self.data_path)
+        if self._h5_mode:
+            self._init_h5()
+        else:
+            self._init_pkl()
+
+    def _is_h5_path(self, datapath):
+        path = Path(datapath)
+        return path.suffix == ".h5" or (path / "interhuman_train.h5").exists()
+
+    def _init_common_labels(self):
+        self._action_to_label = {0: 0}
+        self._label_to_action = {0: 0}
+        self._action_classes = {0: "interaction"}
+        self.num_actions = 1
+
+    def _init_h5(self):
+        self._h5_paths = self._resolve_h5_paths(self.data_path)
+        eval_split = "val" if self.split == "val" else "test"
+        train_entries = [("train", key) for key in self._read_h5_keys("train")]
+        eval_entries = [(eval_split, key) for key in self._read_h5_keys(eval_split)]
+
+        self.keys = [key for _, key in train_entries + eval_entries]
+        self._h5_entries = train_entries + eval_entries
+
+        n_train = len(train_entries)
+        self._train = np.arange(n_train)
+        self._test = np.arange(n_train, len(self._h5_entries))
+
+        if self.max_samples is not None and self.max_samples > 0:
+            self._train = self._train[:self.max_samples]
+            self._test = self._test[:self.max_samples]
+
+        self._train = self._train[self.shard:][::self.num_shards]
+        self._num_frames_in_video = {
+            i: self._get_h5_frames(i) for i in range(len(self._h5_entries))
+        }
+        self._actions = {i: 0 for i in range(len(self._h5_entries))}
+        self._init_common_labels()
+
+    def _resolve_h5_paths(self, datapath):
+        path = Path(datapath)
+        if path.suffix == ".h5":
+            directory = path.parent
+        else:
+            directory = path
+
+        paths = {
+            split: directory / f"interhuman_{split}.h5"
+            for split in ("train", "val", "test")
+        }
+        missing = [str(path) for path in paths.values() if not path.exists()]
+        if missing:
+            raise FileNotFoundError("Missing InterHuman H5 files: " + ", ".join(missing))
+        return paths
+
+    def _read_h5_keys(self, split):
+        with h5py.File(self._h5_paths[split], "r") as h5:
+            return list(h5.keys())
+
+    def _get_h5_frames(self, data_index):
+        split, key = self._h5_entries[data_index]
+        with h5py.File(self._h5_paths[split], "r") as h5:
+            return int(h5[key].shape[0])
+
+    def _get_h5_handle(self, split):
+        if split not in self._h5_handles:
+            self._h5_handles[split] = h5py.File(self._h5_paths[split], "r")
+        return self._h5_handles[split]
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_h5_handles"] = {}
+        return state
+
+    def _sample_frame_indices(self, nframes):
+        if self.num_frames == -1 and (self.max_len == -1 or nframes <= self.max_len):
+            return np.arange(nframes)
+
+        if self.num_frames == -2:
+            if self.min_len <= 0:
+                raise ValueError("You should put a min_len > 0 for num_frames == -2 mode")
+            max_frame = min(nframes, self.max_len) if self.max_len != -1 else nframes
+            num_frames = random.randint(self.min_len, max(max_frame, self.min_len))
+        else:
+            num_frames = self.num_frames if self.num_frames != -1 else self.max_len
+
+        if num_frames > nframes:
+            ntoadd = max(0, num_frames - nframes)
+            lastframe = nframes - 1
+            padding = lastframe * np.ones(ntoadd, dtype=int)
+            return np.concatenate((np.arange(0, nframes), padding))
+
+        if self.sampling in ["conseq", "random_conseq"]:
+            step_max = (nframes - 1) // (num_frames - 1)
+            if self.sampling == "conseq":
+                if self.sampling_step == -1 or self.sampling_step * (num_frames - 1) >= nframes:
+                    step = step_max
+                else:
+                    step = self.sampling_step
+            else:
+                step = random.randint(1, step_max)
+
+            lastone = step * (num_frames - 1)
+            shift_max = nframes - lastone - 1
+            shift = random.randint(0, max(0, shift_max - 1))
+            return shift + np.arange(0, lastone + 1, step)
+
+        if self.sampling == "random":
+            choices = np.random.choice(range(nframes), num_frames, replace=False)
+            return sorted(choices)
+
+        raise ValueError("Sampling not recognized.")
+
+    def _load_h5(self, data_index, frame_ix):
+        split, key = self._h5_entries[data_index]
+        value = self._get_h5_handle(split)[key][:][frame_ix].astype("float32")
+        return torch.from_numpy(value).permute(1, 2, 0).contiguous().float()
+
+    def _get_item_data_index(self, data_index):
+        if not self._h5_mode:
+            return super()._get_item_data_index(data_index)
+
+        nframes = self._num_frames_in_video[data_index]
+        frame_ix = self._sample_frame_indices(nframes)
+        output = {
+            "inp": self._load_h5(data_index, frame_ix),
+            "action": self.get_label(data_index),
+            "action_text": self.action_to_action_name(self.get_action(data_index)),
+            "sample_id": self.keys[data_index],
+        }
+        return output
+
+    def _init_pkl(self):
+        self.motion_dir = os.path.join(self.data_path, "motions")
+        self.label_path = os.path.join(
+            self.data_path, "annotations_interhuman", "interhuman_label.json"
+        )
+        split_dir = os.path.join(self.data_path, "split")
+
+        with open(self.label_path, "r") as f:
+            self._ar_labels = {str(k): int(v) for k, v in json.load(f).items()}
+
+        with open(os.path.join(split_dir, "train.txt"), "r") as f:
+            train_ids = [line.strip() for line in f if line.strip()]
+        with open(os.path.join(split_dir, "test.txt"), "r") as f:
+            test_ids = [line.strip() for line in f if line.strip()]
+        if self.split == "val":
+            with open(os.path.join(split_dir, "val.txt"), "r") as f:
+                test_ids = [line.strip() for line in f if line.strip()]
+
+        self.keys = self._valid_ids(train_ids) + self._valid_ids(test_ids)
+        n_train = len(self._valid_ids(train_ids))
+        self._train = np.arange(n_train)
+        self._test = np.arange(n_train, len(self.keys))
+
+        if self.max_samples is not None and self.max_samples > 0:
+            self._train = self._train[:self.max_samples]
+            self._test = self._test[:self.max_samples]
+
+        self._train = self._train[self.shard:][::self.num_shards]
+        self._cache = {}
+        self._num_frames_in_video = {
+            i: self._get_frames(self.keys[i]) for i in range(len(self.keys))
+        }
+        self._actions = {i: 0 for i in range(len(self.keys))}
+        self._init_common_labels()
+
+    def _valid_ids(self, ids):
+        valid = []
+        for sid in ids:
+            path = os.path.join(self.motion_dir, f"{sid}.pkl")
+            if sid not in self._ar_labels or not os.path.exists(path):
+                continue
+            with open(path, "rb") as f:
+                item = pickle.load(f)
+            if int(item.get("frames", 0)) <= 0:
+                continue
+            valid.append(sid)
+        return valid
+
+    def _load_item(self, sid):
+        if sid not in self._cache:
+            with open(os.path.join(self.motion_dir, f"{sid}.pkl"), "rb") as f:
+                self._cache[sid] = pickle.load(f)
+        return self._cache[sid]
+
+    def _get_frames(self, sid):
+        return int(self._load_item(sid)["frames"])
+
+    def _person_pose(self, person):
+        root = person["root_orient"]
+        body = person["pose_body"]
+        # InterHuman stores root + 21 SMPL body joints. The local SMPL layer
+        # expects 24 rotations including root, so pad the two missing joints.
+        pad = np.zeros((root.shape[0], 6), dtype=root.dtype)
+        return np.concatenate([root, body, pad], axis=1).reshape(root.shape[0], 24, 3)
+
+    def _ordered_people(self, ind):
+        sid = self.keys[ind]
+        item = self._load_item(sid)
+        p1, p2 = item["person1"], item["person2"]
+        if self._ar_labels[sid] == 1:
+            p1, p2 = p2, p1
+        return p1, p2
+
+    def _load_joints3D(self, ind, frame_ix):
+        actor, reactor = self._ordered_people(ind)
+        trans = np.concatenate([actor["trans"], reactor["trans"]], axis=1)
+        return trans[frame_ix, None, :].astype("float32")
+
+    def _load_rotvec(self, ind, frame_ix):
+        actor, reactor = self._ordered_people(ind)
+        pose = np.concatenate(
+            [self._person_pose(actor), self._person_pose(reactor)], axis=2
+        )
+        return pose[frame_ix].astype("float32")

--- a/data_loaders/forecasting/__init__.py
+++ b/data_loaders/forecasting/__init__.py
@@ -1,0 +1,5 @@
+from .interhuman import InterHumanForecastDataset
+from .tensors import forecasting_collate
+
+
+__all__ = ["InterHumanForecastDataset", "forecasting_collate"]

--- a/data_loaders/forecasting/interhuman.py
+++ b/data_loaders/forecasting/interhuman.py
@@ -1,0 +1,113 @@
+import random
+from pathlib import Path
+
+import h5py
+import torch
+from torch.utils.data import Dataset, get_worker_info
+
+from utils.forecasting_motion import extract_active_motion
+
+
+class InterHumanForecastDataset(Dataset):
+    def __init__(
+        self,
+        data_path,
+        split,
+        window_len=150,
+        obs_len=30,
+        pred_len=120,
+        max_samples=-1,
+        seed=0,
+    ):
+        if split not in ("train", "val", "test"):
+            raise ValueError("split 必须是 train/val/test，当前为 {}".format(split))
+        if obs_len + pred_len != window_len:
+            raise ValueError("obs_len + pred_len 必须等于 window_len")
+
+        self.data_path = data_path
+        self.split = split
+        self.window_len = int(window_len)
+        self.obs_len = int(obs_len)
+        self.pred_len = int(pred_len)
+        self.max_samples = int(max_samples) if max_samples is not None else -1
+        self.seed = int(seed)
+        self._rng = random.Random(self.seed)
+        self._h5_handle = None
+        self.h5_path = self._resolve_h5_path(data_path, split)
+        self.entries = self._read_entries()
+
+    def _resolve_h5_path(self, data_path, split):
+        path = Path(data_path)
+        if path.suffix == ".h5":
+            return path
+        return path / "interhuman_{}.h5".format(split)
+
+    def _read_entries(self):
+        if not self.h5_path.exists():
+            raise FileNotFoundError(str(self.h5_path))
+
+        entries = []
+        with h5py.File(str(self.h5_path), "r") as h5:
+            for key in h5.keys():
+                length = int(h5[key].shape[0])
+                if length >= self.window_len:
+                    entries.append({"sample_id": str(key), "length": length})
+
+        if self.max_samples is not None and self.max_samples > 0:
+            entries = entries[: self.max_samples]
+        return entries
+
+    def __len__(self):
+        return len(self.entries)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_h5_handle"] = None
+        return state
+
+    def close(self):
+        if self._h5_handle is not None:
+            self._h5_handle.close()
+            self._h5_handle = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def _get_h5_handle(self):
+        if self._h5_handle is None:
+            self._h5_handle = h5py.File(str(self.h5_path), "r")
+        return self._h5_handle
+
+    def _sample_start(self, length):
+        max_start = int(length) - self.window_len
+        if max_start < 0:
+            raise ValueError("length 小于 window_len")
+        if self.split == "train":
+            if get_worker_info() is not None:
+                return random.randint(0, max_start)
+            return self._rng.randint(0, max_start)
+        return max_start // 2
+
+    def __getitem__(self, index):
+        entry = self.entries[index]
+        sample_id = entry["sample_id"]
+        length = int(entry["length"])
+        start = self._sample_start(length)
+        stop = start + self.window_len
+
+        motion = self._get_h5_handle()[sample_id][start:stop]
+        motion = torch.from_numpy(motion).float()
+        active = extract_active_motion(motion)
+        obs = active[: self.obs_len].contiguous()
+        target = active[self.obs_len :].contiguous()
+
+        return {
+            "obs": obs,
+            "target": target,
+            "sample_id": sample_id,
+            "start": int(start),
+            "length": length,
+        }

--- a/data_loaders/forecasting/tensors.py
+++ b/data_loaders/forecasting/tensors.py
@@ -1,0 +1,21 @@
+import torch
+
+
+def forecasting_collate(batch):
+    not_none = [item for item in batch if item is not None]
+    if len(not_none) == 0:
+        raise ValueError("batch 为空")
+
+    obs = torch.stack([item["obs"] for item in not_none], dim=0)
+    target = torch.stack([item["target"] for item in not_none], dim=0)
+    meta = []
+    for item in not_none:
+        meta.append(
+            {
+                "sample_id": item["sample_id"],
+                "start": int(item["start"]),
+                "length": int(item["length"]),
+            }
+        )
+
+    return obs, target, meta

--- a/data_loaders/get_data.py
+++ b/data_loaders/get_data.py
@@ -16,6 +16,9 @@ def get_dataset_class(name):
     elif name == "ntu" or name == "chi3d":
         from .a2m.feeder import Feeder
         return Feeder
+    elif name == "interhuman":
+        from .a2m.interhuman import InterHuman
+        return InterHuman
     else:
         raise ValueError(f'Unsupported dataset name [{name}]')
 
@@ -33,22 +36,25 @@ def get_collate_fn(name, setting, hml_mode='train'):
         return all_ccollate
 
 
-def get_dataset(name, num_frames, num_person, data_path='', pose_rep='rot6d', body_model='smpl', ar_shuffle=False, split='train', hml_mode='train', shard=0, num_shards=1):
+def get_dataset(name, num_frames, num_person, data_path='', pose_rep='rot6d', body_model='smpl', ar_shuffle=False, split='train', hml_mode='train', shard=0, num_shards=1, max_samples=-1):
     DATA = get_dataset_class(name)
     if name in ["humanml", "kit"]:
         dataset = DATA(split=split, num_frames=num_frames, mode=hml_mode, num_person=num_person, datapath=data_path, pose_rep=pose_rep, body_model=body_model, dataname=name, ar_shuffle=ar_shuffle, shard=shard, num_shards=num_shards)
     else:
-        dataset = DATA(split=split, num_frames=num_frames, num_person=num_person, datapath=data_path, pose_rep=pose_rep, dataname=name, body_model=body_model, ar_shuffle=ar_shuffle, shard=shard, num_shards=num_shards)
+        dataset = DATA(split=split, num_frames=num_frames, num_person=num_person, datapath=data_path, pose_rep=pose_rep, dataname=name, body_model=body_model, ar_shuffle=ar_shuffle, shard=shard, num_shards=num_shards, max_samples=max_samples)
     return dataset
 
 
-def get_dataset_loader(name, batch_size, num_frames, num_person, data_path='', pose_rep='rot6d', body_model='smpl', ar_shuffle=False, setting='mdm', split='train', hml_mode='train', shard=0, num_shards=1):
-    dataset = get_dataset(name, num_frames, num_person, data_path, pose_rep, body_model, ar_shuffle, split, hml_mode, shard=shard, num_shards=num_shards)
+def get_dataset_loader(name, batch_size, num_frames, num_person, data_path='', pose_rep='rot6d', body_model='smpl', ar_shuffle=False, setting='mdm', split='train', hml_mode='train', shard=0, num_shards=1, max_samples=-1):
+    dataset = get_dataset(name, num_frames, num_person, data_path, pose_rep, body_model, ar_shuffle, split, hml_mode, shard=shard, num_shards=num_shards, max_samples=max_samples)
     collate = get_collate_fn(name, setting, hml_mode)
 
+    num_workers = 0 if name == "interhuman" or (max_samples is not None and max_samples > 0) else 8
+    persistent_workers = num_workers > 0 and name != "interhuman"
     loader = DataLoader(
         dataset, batch_size=batch_size, shuffle=True,
-        num_workers=8, drop_last=True, collate_fn=collate, persistent_workers=True
+        num_workers=num_workers, drop_last=True, collate_fn=collate,
+        persistent_workers=persistent_workers
     )
 
     return loader

--- a/diffusion/gaussian_diffusion.py
+++ b/diffusion/gaussian_diffusion.py
@@ -1383,8 +1383,10 @@ class GaussianDiffusion:
                 terms["body"] = body_diff
             if self.lambda_transl > 0.:
                 # 3. Relative root translation loss
-                cmotion_transl = cmotion[:,55:56,0:3,:]
-                target_transl, model_output_transl = target[:,55:56,0:3,:], model_output[:,55:56,0:3,:]
+                # 最后一个 slot 保存 root translation；兼容 56-slot SMPL-X 和 25-slot InterHuman H5 表示。
+                cmotion_transl = cmotion[:, -1:, 0:3, :]
+                target_transl = target[:, -1:, 0:3, :]
+                model_output_transl = model_output[:, -1:, 0:3, :]
                 gt_transl_diff = torch.linalg.norm(cmotion_transl - target_transl, axis=2)
                 model_output_transl_diff = torch.linalg.norm(cmotion_transl - model_output_transl, axis=2)
                 transl_diff = self.masked_l2(gt_transl_diff, model_output_transl_diff, mask.squeeze(1))

--- a/docs/ai/context/20260509-111959-interhuman-table4-reproduction-design.md
+++ b/docs/ai/context/20260509-111959-interhuman-table4-reproduction-design.md
@@ -1,0 +1,421 @@
+# InterHuman-AS Table 4 复现设计
+
+## 目标
+
+在当前 ReGenNet 仓库和本地已有 InterHuman 数据的基础上，尽可能复现 `2403.11882v1.pdf` 中 Table 4 的 InterHuman-AS 实验结果。
+
+目标任务是在线、无意图条件的人体动作-反应合成：
+
+```text
+actor motion -> ReGenNet -> reactor motion
+```
+
+论文 Table 4 在 InterHuman-AS 上报告的是文本条件风格的指标：
+
+```text
+R Precision (Top 3)
+FID
+MM Dist
+Diversity
+MModality
+```
+
+因此，本复现设计分为两个层级：
+
+1. 使用全部有效的 InterHuman-AS 样本训练一个完整的反应生成模型。
+2. 复现 Table 4 的评估协议，包括文本-动作检索相关指标。
+
+第一个层级在当前数据和代码适配基础上可行。第二个层级还需要额外的文本数据，以及兼容 InterHuman 的评估器。
+
+## 当前状态
+
+本地数据：
+
+```text
+dataset/interhuman/motions/*.pkl
+dataset/interhuman/annotations_interhuman/interhuman_label.json
+dataset/interhuman/split/train.txt
+dataset/interhuman/split/val.txt
+dataset/interhuman/split/test.txt
+```
+
+过滤后的数据可用性：
+
+```text
+train split: 列出 6022 条，可用 6021 条
+val split:   列出 580 条， 可用 580 条
+test split:  列出 1177 条，可用 1175 条
+```
+
+已知无效或不完整的样本 ID：
+
+```text
+3945
+3433
+4106
+```
+
+当前仓库支持情况：
+
+- 原始代码已经支持 `ntu` 和 `chi3d` 数据路径。
+- 已通过 `data_loaders/a2m/interhuman.py` 为冒烟测试加入 `interhuman` 支持。
+- 小配置下，RTX 3080 可以跑通冒烟训练。
+- 冒烟 DDIM 生成能够产生有限数值的样本。
+
+当前冒烟测试使用的动作表示：
+
+```text
+body_model: smpl
+单人 motion shape: [25, 6, T]
+双人样本 shape:    [25, 12, T]
+```
+
+这足以验证训练链路，但还不是 Table 4 级别复现。
+
+## 所需数据格式
+
+ReGenNet 的 `cmdm` 路径期望每条样本已经按 actor-reactor 顺序配对：
+
+```text
+inp: [J, 2*C, T]
+```
+
+对于 rot6d 的 SMPL 身体表示：
+
+```text
+J = 25
+C = 6
+T = 150
+inp[:, 0:6, :]  = actor motion
+inp[:, 6:12, :] = reactor motion
+```
+
+随后 collate 函数会生成：
+
+```text
+cond["y"]["cmotion"] = actor motion
+motion               = reactor motion
+```
+
+每个 InterHuman `.pkl` 文件包含：
+
+```text
+person1/trans
+person1/root_orient
+person1/pose_body
+person2/trans
+person2/root_orient
+person2/pose_body
+```
+
+actor-reactor 标注决定两个人的顺序：
+
+```text
+0 -> person1 是 actor，person2 是 reactor
+1 -> person2 是 actor，person1 是 reactor
+```
+
+## 预处理方案
+
+新增一个离线转换脚本：
+
+```text
+preprocess/interhuman_as.py
+```
+
+输出：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+```
+
+每个 H5 entry 应存储：
+
+```text
+[T, 25, 12]
+```
+
+其中：
+
+```text
+24 个 SMPL 旋转关节，使用 rot6d 表示
+1 个 translation slot
+actor/reaction 在 channel 维拼接
+```
+
+预处理应执行：
+
+1. 读取 split ID。
+2. 丢弃缺失、无标注或零帧样本。
+3. 应用 actor-reactor 顺序。
+4. 将 axis-angle 转换为 rot6d。
+5. 将 root translation 追加为最后一个 slot。
+6. 保存固定长度或可变长度序列。
+7. 保存 metadata，记录跳过的样本 ID 和原因。
+
+当前在线 loader 可以保留用于开发，但正式训练和评估应使用冻结后的预处理文件，以提升可复现性。
+
+## 模型范围
+
+Table 4 应使用同一类 ReGenNet 架构：
+
+```text
+diffusion model
+Transformer decoder
+online causal mask
+actor motion conditioning
+unconstrained actor intention
+```
+
+论文规模配置：
+
+```text
+arch: online
+layers: 8
+latent_dim: 512
+diffusion_steps: 1000
+noise_schedule: cosine
+num_frames: 150
+DDIM evaluation steps: 5
+```
+
+论文说明 NTU120-AS 和 InterHuman-AS 使用 batch size 64，并在 4 张 A100 GPU 上训练。这个配置不能在单张 10GB RTX 3080 上原样运行。
+
+## 单张 RTX 3080 训练计划
+
+采用分阶段训练。
+
+阶段 1：完整数据冒烟训练
+
+```text
+batch_size: 1
+layers: 2
+latent_dim: 128
+num_frames: 150
+num_steps: 1000
+lambda_orient/body/transl: 0
+```
+
+目的：证明完整 train split 可以被遍历，并且不会出现 NaN 或 OOM。
+
+阶段 2：实用单卡 baseline
+
+```text
+batch_size: 1-2
+layers: 4
+latent_dim: 256
+num_frames: 150
+num_steps: 50k-100k
+DDIM: 5
+```
+
+目的：产生可用的定性样本和粗略指标。
+
+阶段 3：更接近论文配置的训练
+
+```text
+batch_size: 1-2
+gradient_accumulation_steps: 16-64
+effective batch size: 32-64
+layers: 显存允许则 8，否则 4
+latent_dim: 显存允许则 512，否则 256
+num_steps: 300k-600k
+```
+
+所需代码改动：
+
+- 为 `TrainLoop` 增加真正的梯度累积。
+- 将 `microbatch` 和 effective batch size 分离。
+- 分开记录 optimizer step 和 data step。
+
+## Loss 设计
+
+当前冒烟测试关闭了：
+
+```text
+lambda_orient
+lambda_body
+lambda_transl
+```
+
+原因：原始 interaction loss 假设使用 NTU/Chi3D 的 SMPL-X 风格 layout，其中 translation 索引依赖 joint slot `55` 附近的位置。当前 InterHuman 冒烟数据使用的是 SMPL，只有 `25` 个 slot。
+
+要达到 Table 4 级别复现，需要在以下两条路径中选择一条：
+
+路径 A：SMPL 兼容的 interaction loss
+
+- 重写 interaction loss，让任意 body model 都使用最后一个 slot 作为 translation。
+- 从 root joint slot `0` 计算相对朝向。
+- 使用 `rot2xyz` 生成的 SMPL joints 计算 body distance。
+- 这是最适合本地 InterHuman 数据的务实路径。
+
+路径 B：SMPL-X 转换
+
+- 将 InterHuman 的 SMPL body motion 转成 SMPL-X 兼容表示。
+- 保留原始 loss layout。
+- 如果作者内部实际使用的是 SMPL-X，这条路径更接近论文，但需要稳定可靠的 SMPL-to-SMPL-X 转换流程。
+
+建议优先实现：路径 A。
+
+## 文本条件需求
+
+Table 4 不只是 action-conditioned generation。它报告了：
+
+```text
+R Precision
+MM Dist
+```
+
+这些指标需要文本描述和文本-动作评估器。
+
+缺失组件：
+
+```text
+InterHuman text/caption files
+InterHuman text tokenization pipeline
+text-conditioned InterHuman dataset loader
+text-motion matching evaluator
+trained evaluator checkpoint
+Table 4 metric runner
+```
+
+如果本地只有 `motions/*.pkl` 和 actor-reactor 标注，那么可以训练 actor-conditioned reaction generation，但不能复现 Table 4 指标。
+
+## 评估设计
+
+生成评估应构造两组生成结果：
+
+```text
+train-conditioned: actor motions sampled from train split
+test-conditioned:  actor motions sampled from test split
+```
+
+对于 Table 4：
+
+1. 使用 DDIM-5 生成 reactions。
+2. 提取 motion features。
+3. 提取 text features。
+4. 计算：
+   - R Precision Top 3
+   - FID
+   - MM Dist
+   - Diversity
+   - MModality
+5. 使用多个随机种子重复实验。
+6. 报告均值和 95% 置信区间。
+
+需要新增的评估脚本：
+
+```text
+eval/eval_interhuman.py
+eval/interhuman_metrics.py
+```
+
+如果无法获得论文完全一致的 evaluator，结果应标注为 reproduction-attempt metrics，而不是精确的 Table 4 复现。
+
+## 具体实施任务
+
+1. 新增离线 InterHuman-AS 预处理。
+2. 用基于 H5 的 InterHuman loader 替代冒烟测试用的在线 loader。
+3. 增加 SMPL 兼容的 interaction loss。
+4. 为 10GB GPU 训练增加梯度累积。
+5. 增加完整数据训练命令模板。
+6. 增加 InterHuman 采样生成命令。
+7. 获取并验证 InterHuman 文本描述。
+8. 实现 InterHuman text-conditioned loader。
+9. 实现或移植 text-motion evaluator。
+10. 分阶段训练，并与 Table 4 对比。
+
+## 建议命令
+
+完整数据冒烟训练：
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+python -m train.train_mdm \
+  --setting cmdm \
+  --save_dir save/interhuman/smoke_full \
+  --dataset interhuman \
+  --data_path dataset/interhuman \
+  --cond_mask_prob 0 \
+  --num_person 2 \
+  --layers 2 \
+  --latent_dim 128 \
+  --num_frames 150 \
+  --arch online \
+  --overwrite \
+  --pose_rep rot6d \
+  --body_model smpl \
+  --train_platform_type NoPlatform \
+  --unconstrained \
+  --batch_size 1 \
+  --num_steps 1000 \
+  --save_interval 500 \
+  --log_interval 50 \
+  --lambda_orient 0 \
+  --lambda_body 0 \
+  --lambda_transl 0
+```
+
+单卡 baseline 训练：
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+python -m train.train_mdm \
+  --setting cmdm \
+  --save_dir save/interhuman/baseline_3080 \
+  --dataset interhuman \
+  --data_path dataset/interhuman \
+  --cond_mask_prob 0 \
+  --num_person 2 \
+  --layers 4 \
+  --latent_dim 256 \
+  --num_frames 150 \
+  --arch online \
+  --overwrite \
+  --pose_rep rot6d \
+  --body_model smpl \
+  --train_platform_type TensorboardPlatform \
+  --unconstrained \
+  --batch_size 1 \
+  --num_steps 50000 \
+  --save_interval 5000 \
+  --log_interval 100 \
+  --lambda_orient 0 \
+  --lambda_body 0 \
+  --lambda_transl 0
+```
+
+这些命令还不是 Table 4 复现命令。它们是为了在本地硬件上逐步达到稳定 InterHuman-AS 训练的阶段性命令。
+
+## 风险
+
+主要风险：
+
+- 公开仓库没有包含作者的 InterHuman 训练路径。
+- 精确的 Table 4 evaluator 可能不在当前仓库中。
+- 本地文本数据可能不完整。
+- 单张 RTX 3080 的训练速度更慢，batch size 也低于论文规模。
+- SMPL 与 SMPL-X 表示差异可能导致指标不可直接比较。
+- 如果没有完全一致的 evaluator，复现结果只能作为方向性参考，不能视为数值等价复现。
+
+## 验收标准
+
+最低可接受复现：
+
+- 完整 InterHuman-AS train split 能训练，不出现 NaN/OOM。
+- test split 可使用 DDIM-5 生成。
+- 生成样本数值有限，并且可以渲染。
+- 指标能够用文档化的 evaluator 代码稳定计算。
+
+Table 4 级别复现：
+
+- 使用完整 InterHuman-AS train/test split。
+- 使用 actor-reactor 标注。
+- 使用与论文一致的帧长和动作表示。
+- 使用文本描述。
+- 使用与论文兼容的 text-motion evaluator。
+- 报告 Table 4 指标及置信区间。

--- a/docs/ai/context/20260509-111959-interhuman-table4-reproduction-execution-plan.md
+++ b/docs/ai/context/20260509-111959-interhuman-table4-reproduction-execution-plan.md
@@ -1,0 +1,463 @@
+# InterHuman-AS Table 4 复现执行计划
+
+## 执行计划总览
+
+本计划按“先保证训练链路，再保证数据格式，再追评估协议”的顺序推进。不要直接从 Table 4 指标开始做，因为当前仓库缺 InterHuman 正式路径和 evaluator，直接长训会掩盖数据、loss、评估不一致的问题。
+
+推荐执行顺序：
+
+```text
+P0 环境与数据冻结
+P1 InterHuman-AS 离线预处理
+P2 H5 数据加载与全量 smoke
+P3 单卡稳定训练
+P4 生成与定性检查
+P5 文本数据与 evaluator 补齐
+P6 Table 4 指标复现
+```
+
+每个阶段都要留下可复跑的命令、日志、配置和输出文件。所有不确定项必须记录在 `meta.json` 或实验 README 中。
+
+## P0：环境与数据冻结
+
+目标：
+
+确认当前机器、依赖、数据和无效样本清单，形成固定输入。后续所有实验以这个状态为基线。
+
+输入：
+
+```text
+dataset/interhuman/motions/*.pkl
+dataset/interhuman/annotations_interhuman/interhuman_label.json
+dataset/interhuman/split/*.txt
+/home/rpartx3080/.local/micromamba/envs/regennet
+```
+
+输出：
+
+```text
+dataset/interhuman/reproduction_manifest.json
+docs/ai/interhuman_table4_reproduction_log.md
+```
+
+需要记录：
+
+```text
+GPU 型号和显存
+torch/cuda/numpy 版本
+motions 文件数量
+actor-reactor 标注数量
+train/val/test 可用样本数
+过滤掉的样本 ID 和原因
+当前 git diff 摘要
+```
+
+建议命令：
+
+```bash
+nvidia-smi
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python - <<'PY'
+import torch, numpy
+print("torch", torch.__version__, "cuda", torch.cuda.is_available())
+print("gpu", torch.cuda.get_device_name(0) if torch.cuda.is_available() else None)
+print("numpy", numpy.__version__)
+PY
+```
+
+验收：
+
+- manifest 文件存在。
+- 数据统计和已知无效样本一致。
+- 没有训练进程残留。
+
+## P1：InterHuman-AS 离线预处理
+
+目标：
+
+把原始 InterHuman `.pkl` 转换成 ReGenNet 可直接训练的 actor-reactor H5 文件，冻结数据格式。
+
+新增脚本：
+
+```text
+preprocess/interhuman_as.py
+```
+
+输出目录：
+
+```text
+dataset/interhuman/smpl/conditioned/
+```
+
+输出文件：
+
+```text
+interhuman_train.h5
+interhuman_val.h5
+interhuman_test.h5
+meta.json
+```
+
+H5 数据约定：
+
+```text
+key: sample id，例如 "3292"
+value: [T, 25, 12], float32
+```
+
+其中：
+
+```text
+value[:, :, 0:6]  = actor rot6d + translation slot
+value[:, :, 6:12] = reactor rot6d + translation slot
+```
+
+预处理规则：
+
+1. 只处理 split 中存在的 ID。
+2. 必须存在对应 `.pkl`。
+3. 必须存在 actor-reactor 标注。
+4. `frames > 0`。
+5. `person1/person2` 的 `trans/root_orient/pose_body` 必须都是有限值。
+6. 根据标注把 actor 放前，reactor 放后。
+7. `root_orient + pose_body` 组成 22 个 axis-angle joints；补 2 个零关节到 24 个 SMPL rotation joints。
+8. axis-angle 转 rot6d。
+9. 将 translation 写入第 25 个 slot 的前三维，后三维为 0。
+
+需要确认的技术点：
+
+- 当前 `pose_body` 是 21 个 body joints，即 `[T, 63]`。
+- 当前 smoke loader 补 2 个零关节后能通过 SMPL layer。
+- 预处理脚本应复用 `utils.rotation_conversions`，避免重复实现旋转转换。
+
+验收：
+
+- 三个 H5 文件均生成。
+- `meta.json` 包含输入路径、输出路径、样本数、跳过样本、shape、时间戳。
+- 随机抽 10 条 H5 样本，形状均为 `[T,25,12]`，且数值全有限。
+- 与在线 loader 对同一 ID 的输出误差为 0 或浮点可接受误差。
+
+## P2：H5 数据加载与全量 Smoke
+
+目标：
+
+将训练路径切到 H5 数据，验证完整 train split 可迭代、可训练、无 NaN/OOM。
+
+代码改动：
+
+```text
+data_loaders/a2m/interhuman.py
+data_loaders/get_data.py
+```
+
+设计：
+
+- `InterHuman` loader 优先读取 `data_path` 指向的 H5。
+- 如果 `data_path` 是目录，则回退到当前在线 `.pkl` loader。
+- H5 loader 行为与 `Feeder` 保持一致，输出 `inp`。
+- `ccollate()` 继续负责拆 actor 和 reactor。
+
+全量 smoke 配置：
+
+```text
+batch_size: 1
+num_frames: 150
+layers: 2
+latent_dim: 128
+max_samples: -1
+num_steps: 1000
+lambda_orient/body/transl: 0
+```
+
+验收：
+
+- 训练至少 1000 optimizer steps。
+- loss 为有限值。
+- GPU 显存不超过 10GB。
+- 保存 checkpoint。
+- 随机取 test split 生成 4 条样本，输出全有限。
+
+继续条件：
+
+如果此阶段出现 NaN，优先排查数据是否存在非有限值；如果出现 OOM，先降低 `num_frames` 做定位，再恢复 150。
+
+## P3：单卡稳定训练
+
+目标：
+
+在 RTX 3080 上训练一个有实际生成质量的 InterHuman-AS baseline。
+
+推荐配置：
+
+```text
+batch_size: 1
+num_frames: 150
+layers: 4
+latent_dim: 256
+num_steps: 50000
+save_interval: 5000
+log_interval: 100
+DDIM eval steps: 5
+```
+
+需要补充的训练能力：
+
+```text
+gradient_accumulation_steps
+```
+
+建议新增参数：
+
+```text
+--grad_accum_steps
+```
+
+实现位置：
+
+```text
+utils/parser_util.py
+train/training_loop.py
+```
+
+实现原则：
+
+- `batch_size` 表示实际 GPU batch。
+- `grad_accum_steps` 表示多少个 forward/backward 后执行一次 optimizer step。
+- 日志中同时记录 `data_step` 和 `optimizer_step`。
+- checkpoint 文件名以 optimizer step 为准。
+
+验收：
+
+- `grad_accum_steps=1` 时行为与当前训练一致。
+- `grad_accum_steps>1` 时显存不明显增加。
+- 能连续训练至少 5000 optimizer steps。
+- loss 曲线没有持续 NaN 或爆炸。
+
+## P4：生成与定性检查
+
+目标：
+
+在正式指标前确认生成结果不是数值可行但动作崩坏。
+
+需要新增或适配：
+
+```text
+sample/cgenerate_interhuman.py
+render/interhuman_render.py
+```
+
+最小生成协议：
+
+```text
+从 test split 抽 32 条 actor motion
+每条生成 1-3 个 reactor motion
+DDIM steps = 5
+保存 output/cmotion/text/id/length
+```
+
+输出：
+
+```text
+results/interhuman_baseline_3080/results.npy
+results/interhuman_baseline_3080/results.txt
+results/interhuman_baseline_3080/rendered/*.mp4
+```
+
+验收：
+
+- 所有生成 tensor 数值有限。
+- 能转 xyz 或 mesh。
+- 随机 10 个视频中，actor 和 reactor 都能正常显示。
+- 没有明显全零、爆炸、身体飞散。
+
+## P5：文本数据与 Evaluator
+
+目标：
+
+补齐 Table 4 必须的 text-conditioned 评估链路。
+
+当前缺口：
+
+```text
+InterHuman 文本描述文件
+InterHuman 文本 token 处理
+text-motion matching evaluator
+evaluator checkpoint
+R Precision / MM Dist 计算脚本
+```
+
+需要先确认 InterHuman 原始数据包中是否已下载文本部分。建议检查：
+
+```text
+dataset/interhuman/texts
+dataset/interhuman/annots
+dataset/interhuman/captions
+dataset/interhuman/*text*
+```
+
+如果本地没有，需要从 InterHuman 官方数据源补下载文本标注。
+
+实现路线：
+
+1. 先找到 InterHuman 官方文本格式。
+2. 建立 `sample_id -> captions` 映射。
+3. 在 H5 metadata 或单独 JSON 中保存文本。
+4. 新增 `InterHumanTextDataset` 或扩展现有 loader。
+5. 对接现有 HumanML evaluator 框架，或移植 InterGen/InterHuman 官方 evaluator。
+
+验收：
+
+- 任意 sample ID 能取到 motion 和对应文本。
+- batch 中有 `text` 或 token 字段。
+- evaluator 能对 real motion 跑出稳定 feature。
+- R Precision 和 MM Dist 对真实数据能计算。
+
+重要说明：
+
+没有文本数据和 evaluator 时，不能声称复现 Table 4。最多只能声称完成 InterHuman-AS actor-conditioned reaction generation training。
+
+## P6：Table 4 指标复现
+
+目标：
+
+按论文 Table 4 协议生成和评估，形成可对比表格。
+
+目标表格列：
+
+```text
+Method
+R Precision (Top 3)
+FID
+MM Dist
+Diversity
+MModality
+```
+
+复现实验设置：
+
+```text
+dataset: InterHuman-AS
+setting: online, unconstrained
+num_frames: 150
+DDIM steps: 5
+replication_times: 20 如果时间允许，否则先 3
+```
+
+生成规模：
+
+优先级从低到高：
+
+```text
+debug: 64 samples
+small: 512 samples
+paper-attempt: full test split or 1000 samples
+```
+
+验收：
+
+- `Real` 指标可计算。
+- ReGenNet 指标可计算。
+- 每次评估保存原始 JSON/YAML。
+- 表格脚本能输出均值和置信区间。
+
+结果标注规则：
+
+- 如果 evaluator 与论文不完全一致，表格标题必须写 `Reproduction Attempt`。
+- 如果模型配置低于论文，例如 `layers=4, latent_dim=256`，表格备注必须写明。
+- 如果只跑 3 次而不是 20 次，置信区间备注必须写明。
+
+## 文件级任务清单
+
+### 新增文件
+
+```text
+preprocess/interhuman_as.py
+eval/eval_interhuman.py
+eval/interhuman_metrics.py
+sample/cgenerate_interhuman.py
+docs/ai/interhuman_table4_reproduction_log.md
+```
+
+### 修改文件
+
+```text
+data_loaders/a2m/interhuman.py
+data_loaders/get_data.py
+utils/parser_util.py
+utils/model_util.py
+train/training_loop.py
+sample/cgenerate.py 或新增专用脚本
+```
+
+### 可选修改
+
+```text
+diffusion/gaussian_diffusion.py
+```
+
+仅当启用 SMPL-compatible interaction loss 时修改。
+
+## 决策点
+
+### 决策点 1：是否坚持 SMPL-X
+
+当前 InterHuman 原始数据是 SMPL body 参数。若坚持 SMPL-X，需要额外转换流程，风险高。
+
+建议：
+
+```text
+先使用 SMPL 完成可复现训练和 evaluator。
+再单独评估 SMPL-X 转换必要性。
+```
+
+### 决策点 2：是否必须完全复现 Table 4 数值
+
+如果目标是论文级数值对齐，必须获得和作者一致的 evaluator 或非常接近的官方 evaluator。
+
+如果目标是工程复现，则可以使用文档化 evaluator，结果命名为 reproduction attempt。
+
+### 决策点 3：训练预算
+
+RTX 3080 单卡长训成本较高。建议先确认：
+
+```text
+是否接受 50k-100k steps baseline
+是否需要 300k+ steps 长训
+是否能使用远程多卡机器
+```
+
+## 预计时间
+
+粗略估计：
+
+```text
+P0: 0.5 天
+P1: 1 天
+P2: 0.5 天
+P3: 1-5 天训练时间，取决于 steps
+P4: 0.5-1 天
+P5: 2-5 天，取决于文本数据和 evaluator 来源
+P6: 1-3 天，取决于评估次数
+```
+
+如果只做单卡 baseline，不追完整 Table 4：
+
+```text
+2-4 天可得到第一个可用模型和可视化结果
+```
+
+如果追 Table 4 级别复现：
+
+```text
+至少 1-2 周，并且依赖文本数据和 evaluator 是否顺利获得
+```
+
+## 下一步建议
+
+立即执行的下一步：
+
+1. 写 `preprocess/interhuman_as.py`，把当前在线转换固化成 H5。
+2. 用 H5 loader 跑全量 1000 step smoke。
+3. 检查本地是否有 InterHuman 文本标注。
+4. 再决定是否开始 50k step 单卡 baseline。
+
+不要立即开始 300k+ steps 长训。当前最大不确定性不是训练能不能跑，而是 Table 4 evaluator 和文本条件链路是否能对齐。

--- a/docs/ai/context/20260509-112429-interhuman-table4-plan-review.md
+++ b/docs/ai/context/20260509-112429-interhuman-table4-plan-review.md
@@ -1,0 +1,238 @@
+# InterHuman-AS Table 4 执行计划审查
+
+## 结论
+
+当前执行计划需要补充，而且应先纠正目标指标。
+
+设计文档把 `2403.11882v1.pdf` 的 Table 4 写成了文本条件指标：
+
+```text
+R Precision
+FID
+MM Dist
+Diversity
+MModality
+```
+
+但本地 PDF 中 Table 4 的标题是：
+
+```text
+Comparison to state-of-the-arts on the online, unconstrained setting for human action-reaction synthesis on the InterHuman-AS dataset.
+```
+
+该表列为：
+
+```text
+Method
+FID
+Acc.
+Div.
+Multimod.
+```
+
+因此，复现 Table 4 的主路径应是 action-conditioned / actor-conditioned reaction generation 的 ST-GCN feature 评估链路，而不是 text-motion evaluator 链路。文本评估属于论文附录中 text-conditioned human reaction generation 的指标说明，不应阻塞 Table 4。
+
+## 当前项目确认
+
+InterHuman 在线 loader 已存在：
+
+```text
+data_loaders/a2m/interhuman.py
+```
+
+它会读取：
+
+```text
+dataset/interhuman/motions/*.pkl
+dataset/interhuman/annotations_interhuman/interhuman_label.json
+dataset/interhuman/split/*.txt
+```
+
+当前输出经 `ccollate()` 后可得到：
+
+```text
+motion:  [B, 25, 6, 150]
+cmotion: [B, 25, 6, 150]
+```
+
+本地 InterHuman 数据没有发现 text/caption 目录，只有 motions、motions_processed、actor-reactor 标注和 split。
+
+当前 `sample/cgenerate.py` 不适合直接作为 InterHuman 生成入口：
+
+- 只对 `chi3d` 设置 `max_frames=150`，`interhuman` 会落到 60。
+- `is_using_data=True` 时后续仍使用 `action_text`，存在未定义变量风险。
+- 非数据路径依赖 `_get_item_cmotion_index()`，而 `InterHuman` loader 当前没有实现该方法。
+
+当前 `eval/eval_cmdm.py` 不支持 InterHuman：
+
+- 只允许 `ntu` 和 `chi3d`。
+- `num_frames` 只为 `ntu/chi3d` 设置。
+- 强制 `body_model='smplx'`。
+
+当前 ST-GCN evaluator 也没有 InterHuman 分支：
+
+- `eval/a2m/stgcn_eval.py` 只给 `ntu` 和 `chi3d` 设置 `num_classes`。
+- 本地已有 recognition checkpoint 只有 `ntu_smplx` 和 `chi3d_smplx`，没有 InterHuman。
+
+当前 interaction loss 对 SMPL 不完整：
+
+- `lambda_transl` 使用固定索引 `55`。
+- InterHuman SMPL 表示只有 `25` 个 slot，translation 在最后一个 slot。
+
+## 计划应补充的内容
+
+### P-1：论文目标校准
+
+在 P0 前新增一个阶段，先确认复现目标：
+
+```text
+Table 4 主指标：FID / Acc. / Div. / Multimod.
+主 evaluator：ST-GCN action recognition feature evaluator
+文本指标：移出 Table 4 主路径，作为可选扩展
+```
+
+验收：
+
+- 设计文档中 Table 4 指标已纠正。
+- P5/P6 不再把 text-motion evaluator 作为 Table 4 必需项。
+- 结果表格列和论文 Table 4 一致。
+
+### P0：补充数据和论文 manifest
+
+P0 除了环境和数据统计，还应记录：
+
+```text
+PDF Table 4 指标列
+本地是否存在 InterHuman text/caption
+本地是否存在 InterHuman recognition checkpoint
+当前使用 SMPL 还是 SMPL-X
+当前计划是否是 exact reproduction 或 reproduction attempt
+```
+
+输出路径建议放在 `docs/ai/context/`，避免使用 `docs/ai/interhuman_table4_reproduction_log.md` 这种不符合项目约定的路径。
+
+### P1：补充 H5 格式对齐检查
+
+P1 需要明确 H5 不只是 `[T,25,12]`，还必须能被现有 `Dataset._load()` 或专用 H5 loader 无歧义读取：
+
+```text
+_poses:    [T, 24, 12]
+_joints3d: [T, 1, 6]
+最终 inp: [25, 12, T]
+ccollate 后 actor/reactor 各为 [25, 6, T]
+```
+
+还应补充 translation 规范：
+
+```text
+以 actor 第 0 帧 translation 为原点
+actor 和 reactor 使用同一个原点
+```
+
+这是当前 `Dataset._load()` 的实际行为。
+
+### P2：补充 loader 单元测试
+
+P2 应增加独立测试或检查脚本，覆盖：
+
+```text
+online pkl loader 与 H5 loader 同 ID、同 frame_ix 输出一致
+train/val/test split 不互相污染
+max_samples 只用于 smoke，不改变 full manifest
+num_workers=8 时 H5 读取不出现句柄共享问题
+```
+
+### P3：补充训练稳定性门禁
+
+梯度累积之外，还应补充：
+
+```text
+保存 args.json 中的 grad_accum_steps
+resume 后 optimizer_step/data_step 一致
+有效 batch size 明确写入日志
+记录每秒 step、显存峰值、预计完成时间
+```
+
+### P4：补充 InterHuman 专用生成入口要求
+
+应明确 `sample/cgenerate_interhuman.py` 的职责：
+
+```text
+只从 test/train loader 取 actor cmotion
+不依赖 action_file/action_name
+强制 num_frames=150
+保存 sample_id、split、frame_ix、cmotion、output、length
+支持 DDIM-5
+```
+
+这比复用当前 `sample/cgenerate.py` 风险低。
+
+### P5：改为 InterHuman ST-GCN recognition evaluator
+
+原 P5 文本链路应改成：
+
+```text
+训练或获取 InterHuman-AS recognition checkpoint
+支持 SMPL 或确定 SMPL-X 转换
+在 eval/eval_cmdm.py 中加入 interhuman 分支
+在 eval/a2m/stgcn_eval.py 中加入 interhuman num_classes
+确认 InterHuman 类别标签来源
+```
+
+关键决策：
+
+```text
+如果 InterHuman-AS 没有可靠动作类别标签，则 Acc. 和 Multimod. 的类别分组无法严格复现 Table 4。
+```
+
+需要先找官方 InterHuman category/text metadata，而不是直接长训 ReGenNet。
+
+### P6：补充 Table 4 结果口径
+
+P6 的目标表格应改成：
+
+```text
+Method
+FID
+Acc.
+Div.
+Multimod.
+```
+
+复现设置应包括：
+
+```text
+train-conditioned
+test-conditioned
+num_seeds=20
+num_samples=1000 或 full test
+DDIM steps=5
+```
+
+如果使用 SMPL 而不是论文描述中的 SMPL-X，结果必须标注：
+
+```text
+SMPL reproduction attempt, not exact Table 4 reproduction
+```
+
+## 建议优先级
+
+优先级 1：
+
+```text
+修正设计文档和执行计划中的 Table 4 指标定义。
+```
+
+优先级 2：
+
+```text
+确认 InterHuman 类别标签和 recognition checkpoint 路线。
+```
+
+优先级 3：
+
+```text
+再实现 H5 预处理、H5 loader 和全量 smoke。
+```
+
+如果不先解决 evaluator 和类别标签，后续训练可以产生模型，但无法严肃复现 Table 4。

--- a/docs/ai/context/20260509-112706-interhuman-p0-manifest.md
+++ b/docs/ai/context/20260509-112706-interhuman-p0-manifest.md
@@ -1,0 +1,78 @@
+# InterHuman-AS P0 环境与数据冻结
+
+## 输出
+
+已生成 manifest：
+
+```text
+dataset/interhuman/reproduction_manifest.json
+```
+
+## 目标口径
+
+Table 4 主指标：
+
+```text
+FID
+Acc.
+Div.
+Multimod.
+```
+
+非主路径指标：
+
+```text
+R Precision
+MM Dist
+```
+
+## 环境
+
+```text
+GPU: NVIDIA GeForce RTX 3080, 10240 MiB
+Driver: 550.107.02
+Python: 3.7.13
+Torch: 1.7.1
+CUDA: 11.0
+NumPy: 1.21.5
+h5py: 3.7.0
+```
+
+## 数据统计
+
+```text
+motions/*.pkl: 7776
+actor-reactor labels: 7776
+```
+
+split 可用性：
+
+```text
+train: listed 6022, valid 6021, skipped 1
+val:   listed 580,  valid 580,  skipped 0
+test:  listed 1177, valid 1175, skipped 2
+```
+
+跳过样本：
+
+```text
+train/3945: missing_actor_reactor_label
+test/3433:  missing_actor_reactor_label
+test/4106:  missing_actor_reactor_label
+```
+
+说明：
+
+这些样本即使本地存在 `.pkl`，也不能进入 actor-reactor 训练协议，因为缺少可用的 actor-reactor 标注。
+
+## 缺口
+
+本地未发现 InterHuman text/caption 数据目录。
+
+本地未发现 InterHuman recognition checkpoint：
+
+```text
+recognition_training/*interhuman*
+```
+
+因此 P5 必须补齐 InterHuman 类别标签与 ST-GCN recognition evaluator，否则无法严格复现 Table 4 的 `Acc.` 和 `Multimod.`。

--- a/docs/ai/context/20260509-112706-interhuman-p1-p2-implementation.md
+++ b/docs/ai/context/20260509-112706-interhuman-p1-p2-implementation.md
@@ -1,0 +1,129 @@
+# InterHuman-AS P1/P2 实施记录
+
+## 已完成
+
+P1 离线预处理：
+
+```text
+preprocess/interhuman_as.py
+```
+
+已生成：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+```
+
+输出规模：
+
+```text
+train h5: 2.0G
+val h5:   218M
+test h5:  406M
+```
+
+样本数：
+
+```text
+train: listed 6022, written 6021, skipped 1
+val:   listed 580,  written 580,  skipped 0
+test:  listed 1177, written 1175, skipped 2
+```
+
+跳过原因：
+
+```text
+missing_actor_reactor_label
+```
+
+P2 H5 loader：
+
+```text
+data_loaders/a2m/interhuman.py
+```
+
+新增能力：
+
+- `data_path` 指向 `dataset/interhuman/smpl/conditioned` 时读取 H5。
+- `data_path` 指向 `interhuman_train.h5` 时从同目录解析 train/val/test H5。
+- `data_path` 指向 `dataset/interhuman` 时保留在线 `.pkl` loader。
+- H5 文件句柄在 worker 内懒加载，避免跨进程共享句柄。
+
+## 校验
+
+P1 对齐校验：
+
+```text
+train/10:    max_abs_diff_vs_online_loader = 0.0
+train/3292:  max_abs_diff_vs_online_loader = 0.0
+train/4476:  max_abs_diff_vs_online_loader = 0.0
+val/1008:    max_abs_diff_vs_online_loader = 0.0
+val/1024:    max_abs_diff_vs_online_loader = 0.0
+test/1:      max_abs_diff_vs_online_loader = 0.0
+test/100:    max_abs_diff_vs_online_loader = 0.0
+test/1118:   max_abs_diff_vs_online_loader = 0.0
+test/6539:   max_abs_diff_vs_online_loader = 0.0
+```
+
+P2 batch 校验：
+
+```text
+motion:  [B, 25, 6, 150]
+cmotion: [B, 25, 6, 150]
+finite:  True
+```
+
+`num_workers=8` 可取 batch：
+
+```text
+len: 6021
+batch: [1, 25, 6, 150]
+finite: True
+```
+
+最小训练 smoke：
+
+```text
+save_dir: save/interhuman/h5_loader_smoke
+num_steps: 4
+max_samples: 2
+layers: 2
+latent_dim: 128
+batch_size: 1
+lambda_orient/body/transl: 0
+```
+
+训练进入实际 batch，loss：
+
+```text
+step[0]: loss[0.67435]
+step[1]: loss[0.62534]
+```
+
+## 注意事项
+
+`num_steps=2` 时没有实际训练，因为当前 `TrainLoop` 使用：
+
+```text
+num_epochs = num_steps // (len(data) * world_size + 1)
+```
+
+当 `num_steps < len(data)+1` 时 `num_epochs=0`。后续 smoke 命令必须保证 `num_steps >= len(data)+1`，或者在训练循环中修正这个边界。
+
+## 下一步
+
+进入 P3 前建议先做一个 1000 step H5 full smoke：
+
+```text
+batch_size: 1
+layers: 2
+latent_dim: 128
+num_frames: 150
+num_steps: 1000
+lambda_orient/body/transl: 0
+```
+
+如果 full smoke 稳定，再实现 `--grad_accum_steps`。

--- a/docs/ai/context/20260509-112706-interhuman-table4-reproduction-design-corrected.md
+++ b/docs/ai/context/20260509-112706-interhuman-table4-reproduction-design-corrected.md
@@ -1,0 +1,116 @@
+# InterHuman-AS Table 4 复现设计修正版
+
+## 目标校准
+
+复现目标是 `2403.11882v1.pdf` 中 Table 4：
+
+```text
+online, unconstrained setting
+InterHuman-AS dataset
+actor motion -> ReGenNet -> reactor motion
+```
+
+本地 PDF 中 Table 4 的指标列是：
+
+```text
+FID
+Acc.
+Div.
+Multimod.
+```
+
+因此 Table 4 主路径是 actor-conditioned / action-conditioned reaction generation 的 ST-GCN feature 评估链路，不是 text-motion retrieval 链路。
+
+## 非目标
+
+以下指标不属于 Table 4 主路径：
+
+```text
+R Precision
+MM Dist
+text-motion matching evaluator
+```
+
+这些属于 text-conditioned motion generation 的评估口径，只能作为后续扩展，不能阻塞 Table 4 复现。
+
+## 当前可行路径
+
+当前仓库已有 InterHuman 在线 loader：
+
+```text
+data_loaders/a2m/interhuman.py
+```
+
+经 `ccollate()` 后输出：
+
+```text
+motion:  [B, 25, 6, 150]
+cmotion: [B, 25, 6, 150]
+```
+
+这说明训练基础链路的 shape 可用。
+
+## 关键缺口
+
+要复现 Table 4，还缺：
+
+```text
+离线 H5 预处理
+H5 InterHuman loader
+InterHuman 专用生成入口
+InterHuman ST-GCN recognition checkpoint
+InterHuman evaluator 分支
+InterHuman 类别标签来源
+SMPL 与 SMPL-X 口径确认
+```
+
+如果最终使用 SMPL 而不是论文描述中的 SMPL-X，结果必须标注为：
+
+```text
+SMPL reproduction attempt, not exact Table 4 reproduction
+```
+
+## 数据格式
+
+H5 entry 使用：
+
+```text
+key: sample id
+value: [T, 25, 12]
+```
+
+其中：
+
+```text
+value[:, :24, 0:6]   = actor rot6d
+value[:, 24, 0:3]    = actor translation
+value[:, :24, 6:12]  = reactor rot6d
+value[:, 24, 6:9]    = reactor translation
+其他 translation padding 通道为 0
+```
+
+translation 规范：
+
+```text
+以 actor 第 0 帧 translation 为原点
+actor 和 reactor 使用同一个原点
+```
+
+该规范与当前 `Dataset._load()` 的双人 translation 处理保持一致。
+
+## 验收标准
+
+最低可接受：
+
+- 完整 train split 可训练 1000 step，不出现 NaN/OOM。
+- test split 可 DDIM-5 生成。
+- 生成结果和 actor 条件均数值有限。
+- 可用文档化 evaluator 输出 `FID / Acc. / Div. / Multimod.`。
+
+Table 4 级别：
+
+- 使用完整 InterHuman-AS train/test split。
+- 使用 actor-reactor 标注。
+- 使用 150 帧、6D rotation。
+- 使用与论文兼容的 ST-GCN feature evaluator。
+- 报告 20 次随机种子的均值和 95% 置信区间。

--- a/docs/ai/context/20260509-112706-interhuman-table4-reproduction-execution-plan-corrected.md
+++ b/docs/ai/context/20260509-112706-interhuman-table4-reproduction-execution-plan-corrected.md
@@ -1,0 +1,192 @@
+# InterHuman-AS Table 4 复现执行计划修正版
+
+## 阶段总览
+
+```text
+P-1 论文目标校准
+P0 环境与数据冻结
+P1 InterHuman-AS 离线 H5 预处理
+P2 H5 loader 与全量 smoke
+P3 单卡稳定训练
+P4 InterHuman 专用生成与定性检查
+P5 InterHuman ST-GCN evaluator
+P6 Table 4 指标复现
+```
+
+## P-1：论文目标校准
+
+目标：
+
+纠正 Table 4 指标口径，避免把 text-motion 指标误作为主路径。
+
+验收：
+
+- Table 4 主指标明确为 `FID / Acc. / Div. / Multimod.`。
+- text evaluator 从 Table 4 主路径移出。
+- 后续计划以 ST-GCN recognition feature evaluator 为主。
+
+## P0：环境与数据冻结
+
+输出：
+
+```text
+dataset/interhuman/reproduction_manifest.json
+docs/ai/context/YYYYMMDD-HHMMSS-interhuman-p0-manifest.md
+```
+
+需要记录：
+
+```text
+GPU 型号和显存
+torch/cuda/numpy/h5py 版本
+motions 文件数量
+split 样本数
+actor-reactor 标注数量
+可用样本数与跳过原因
+是否存在 text/caption
+是否存在 InterHuman recognition checkpoint
+当前 git status 摘要
+```
+
+## P1：InterHuman-AS 离线 H5 预处理
+
+新增脚本：
+
+```text
+preprocess/interhuman_as.py
+```
+
+输出：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+```
+
+H5 entry：
+
+```text
+[T, 25, 12] float32
+```
+
+规则：
+
+1. 读取 split ID。
+2. 过滤缺失 `.pkl`、缺 actor-reactor 标注、零帧、非有限值、shape 异常样本。
+3. 按 actor-reactor 标注排序。
+4. 将 `root_orient + pose_body` 组成 22 个 axis-angle joints。
+5. 补 2 个零关节到 24 个 SMPL rotation joints。
+6. axis-angle 转 rot6d。
+7. translation 以 actor 第 0 帧为原点归一化。
+8. 写入第 25 个 slot。
+9. 保存 meta，包括跳过样本和原因。
+
+验收：
+
+- 三个 H5 和 `meta.json` 均生成。
+- 随机样本 shape 为 `[T,25,12]` 且数值有限。
+- 与当前在线 loader 对同一 ID、同一 frame_ix 输出一致或误差在浮点范围内。
+
+## P2：H5 loader 与全量 smoke
+
+代码改动：
+
+```text
+data_loaders/a2m/interhuman.py
+data_loaders/get_data.py
+```
+
+要求：
+
+- `data_path` 指向 H5 时读取 H5。
+- `data_path` 指向目录时保留当前 `.pkl` 在线 loader。
+- `ccollate()` 后 actor/reactor 各为 `[25,6,T]`。
+- `num_workers=8` 时 H5 不共享失效文件句柄。
+
+验收：
+
+- 1000 step smoke 可完成。
+- loss 有限。
+- 保存 checkpoint。
+- DDIM-5 生成 4 条 test 样本且数值有限。
+
+## P3：单卡稳定训练
+
+新增能力：
+
+```text
+--grad_accum_steps
+```
+
+要求：
+
+- `batch_size` 是实际 GPU batch。
+- `grad_accum_steps` 控制多少个 backward 后 optimizer step。
+- `args.json` 保存该参数。
+- 日志记录 data step、optimizer step、effective batch size、显存峰值。
+- resume 后 step 口径一致。
+
+## P4：InterHuman 专用生成与定性检查
+
+新增脚本：
+
+```text
+sample/cgenerate_interhuman.py
+```
+
+要求：
+
+- 不依赖 `action_file` 或 `action_name`。
+- 只从 train/test loader 取 actor `cmotion`。
+- 强制或默认 `num_frames=150`。
+- 支持 DDIM-5。
+- 保存 `sample_id`、`split`、`length`、`cmotion`、`output`。
+
+## P5：InterHuman ST-GCN evaluator
+
+目标：
+
+补齐 Table 4 的 `FID / Acc. / Div. / Multimod.` 评估链路。
+
+任务：
+
+1. 确认 InterHuman 类别标签来源。
+2. 训练或获取 InterHuman-AS recognition checkpoint。
+3. 为 `eval/eval_cmdm.py` 增加 `interhuman` 分支。
+4. 为 `eval/a2m/stgcn_eval.py` 增加 `interhuman` 参数。
+5. 明确 SMPL 或 SMPL-X 评估口径。
+
+门禁：
+
+如果没有可靠类别标签，`Acc.` 和 `Multimod.` 不能声称严格复现 Table 4。
+
+## P6：Table 4 指标复现
+
+目标表格：
+
+```text
+Method
+FID
+Acc.
+Div.
+Multimod.
+```
+
+协议：
+
+```text
+dataset: InterHuman-AS
+setting: online, unconstrained
+num_frames: 150
+DDIM steps: 5
+num_samples: 1000 或 full test
+num_seeds: 20
+```
+
+结果标注：
+
+- evaluator 与论文不完全一致时写 `Reproduction Attempt`。
+- 使用 SMPL 时写 `SMPL reproduction attempt`。
+- 训练配置低于论文时写明 `layers / latent_dim / effective batch size / steps`。

--- a/docs/ai/context/20260509-133206-parser-util-comment-plan.md
+++ b/docs/ai/context/20260509-133206-parser-util-comment-plan.md
@@ -1,0 +1,21 @@
+# parser_util.py 中文注释补充计划
+
+## 背景
+
+用户希望按 `train/train_mdm.py` 中的编号式中文注释风格，继续解释 `utils/parser_util.py`，当前关注点在 `utils/parser_util.py:255` 附近。
+
+## 必须保持不变
+
+- 不改变任何 argparse 参数名、默认值、choices、required 设置。
+- 不改变训练、采样、编辑、评估入口的参数组合顺序。
+- 不改变 `parse_and_load_from_model` / `parse_and_load_from_model_wo_data` 的覆盖逻辑。
+
+## 注释策略
+
+- 只补充中文注释，解释参数组和入口函数的用途。
+- 使用类似 `train_mdm.py` 的编号式注释，让读者能顺着执行路径理解。
+- 重点说明 `rec_model_path` 是评估用动作识别模型，不是 ReGenNet 生成模型 checkpoint。
+
+## 验证
+
+- 修改后运行 `python -m py_compile utils/parser_util.py`，确认注释改动没有破坏语法。

--- a/docs/ai/context/20260509-134022-interhuman-h5-full-smoke.md
+++ b/docs/ai/context/20260509-134022-interhuman-h5-full-smoke.md
@@ -1,0 +1,114 @@
+# InterHuman-AS H5 Full Smoke 记录
+
+## 目的
+
+验证完整冻结 H5 数据路径在 `num_steps=1000` 时确实执行 1000 个训练 step，并能正常保存 checkpoint、自然退出。
+
+## 代码修正
+
+修正 `train/training_loop.py`：
+
+- `num_epochs` 改为按剩余 step 和 dataloader 长度向上取整。
+- 每个 batch 前以 `num_steps` 作为硬停止条件。
+- `num_steps < len(data)` 时不再出现 `num_epochs=0`。
+- 训练提前停止时尝试关闭 dataloader iterator。
+
+修正 `data_loaders/get_data.py`：
+
+- InterHuman 固定 `num_workers=0`。
+- 原因是完整 H5 loader 在提前达到 `num_steps` 后，PyTorch 1.7 + 多 worker 会留下 worker 子进程并阻塞进程退出。
+
+修正 `train/train_mdm.py`：
+
+- 修复当前 dirty worktree 中的 `da ta` 拼写错误，恢复为 `data`。
+
+## 最终 smoke 命令
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+python -m train.train_mdm \
+  --setting cmdm \
+  --save_dir save/interhuman/h5_full_1000_smoke_noworkers \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --cond_mask_prob 0 \
+  --num_person 2 \
+  --layers 2 \
+  --latent_dim 128 \
+  --num_frames 150 \
+  --arch online \
+  --overwrite \
+  --pose_rep rot6d \
+  --body_model smpl \
+  --train_platform_type NoPlatform \
+  --unconstrained \
+  --batch_size 1 \
+  --num_steps 1000 \
+  --save_interval 500 \
+  --log_interval 100 \
+  --lambda_orient 0 \
+  --lambda_body 0 \
+  --lambda_transl 0 \
+  --max_samples -1
+```
+
+## 结果
+
+训练正常达到 1000 step 并自然退出。
+
+loss 记录：
+
+```text
+step[0]:   loss[0.65867]
+step[100]: loss[0.15427]
+step[200]: loss[0.11790]
+step[300]: loss[0.10618]
+step[400]: loss[0.09846]
+step[500]: loss[0.09387]
+step[600]: loss[0.09114]
+step[700]: loss[0.08892]
+step[800]: loss[0.08640]
+step[900]: loss[0.08422]
+```
+
+输出文件：
+
+```text
+save/interhuman/h5_full_1000_smoke_noworkers/args.json
+save/interhuman/h5_full_1000_smoke_noworkers/model000000000.pt
+save/interhuman/h5_full_1000_smoke_noworkers/model000000500.pt
+save/interhuman/h5_full_1000_smoke_noworkers/model000001000.pt
+save/interhuman/h5_full_1000_smoke_noworkers/opt000000000.pt
+save/interhuman/h5_full_1000_smoke_noworkers/opt000000500.pt
+save/interhuman/h5_full_1000_smoke_noworkers/opt000001000.pt
+```
+
+checkpoint 加载验证：
+
+```text
+model000000000.pt: OrderedDict, 50 keys
+model000000500.pt: OrderedDict, 50 keys
+model000001000.pt: OrderedDict, 50 keys
+opt000001000.pt: dict, 2 keys
+```
+
+进程状态：
+
+```text
+无残留 train_mdm / micromamba run 进程
+无残留 GPU compute app
+```
+
+## 注意
+
+早先使用 `num_workers=8` 的 1000 step 训练也写出了 `model000001000.pt`，但进程退出时挂住，需要手动终止。最终有效验收以 `h5_full_1000_smoke_noworkers` 为准。
+
+## 下一步
+
+进入 P3：
+
+```text
+实现 --grad_accum_steps
+```
+
+在实现前保留当前 1000 step smoke checkpoint，作为 H5 数据链路稳定性的基线。

--- a/docs/ai/context/20260509-160403-model-util-create-model-diffusion-comments.md
+++ b/docs/ai/context/20260509-160403-model-util-create-model-diffusion-comments.md
@@ -1,0 +1,23 @@
+# model_util.py 创建模型与 diffusion 注释计划
+
+## 背景
+
+用户希望给 `utils/model_util.py` 中 `create_model_and_diffusion(args, data)` 每一行加中文注释，解释模型和 diffusion 是如何创建的。
+
+## 范围
+
+- 只修改 `utils/model_util.py` 的 `create_model_and_diffusion()` 函数附近注释。
+- 不修改任何训练逻辑、参数、返回值或函数调用顺序。
+- 保持当前 `setting == 'cmdm'` 的行为不变。
+
+## 注释重点
+
+- `args.setting` 用来选择训练框架。
+- `CMDM(**get_model_args(args, data))` 先根据参数和数据集信息创建网络。
+- `args.num_person = 1` 是因为 diffusion 只处理拆分后的 reactor 单人目标动作。
+- `create_gaussian_diffusion(args)` 创建扩散训练/采样规则。
+- 返回的 `model, diffusion` 会交给训练循环使用。
+
+## 验证
+
+- 修改后运行 `python3 -m py_compile utils/model_util.py`。

--- a/docs/ai/context/20260510-100418-interhuman-p3-grad-accum.md
+++ b/docs/ai/context/20260510-100418-interhuman-p3-grad-accum.md
@@ -1,0 +1,122 @@
+# InterHuman-AS P3 梯度累积实施记录
+
+## 目标
+
+为单张 RTX 3080 训练增加梯度累积能力，使显存 batch size 和 effective batch size 分离。
+
+## 代码改动
+
+新增训练参数：
+
+```text
+--grad_accum_steps
+```
+
+位置：
+
+```text
+utils/parser_util.py
+```
+
+训练逻辑：
+
+```text
+train/training_loop.py
+```
+
+语义：
+
+```text
+batch_size: 实际 GPU batch
+grad_accum_steps: 每次 optimizer step 前累积的 forward/backward 次数
+num_steps: optimizer steps
+effective_batch_size = batch_size * world_size * grad_accum_steps
+```
+
+实现要点：
+
+- `grad_accum_steps=1` 保持原行为。
+- 每次 backward 的 loss 按 `1 / grad_accum_steps` 缩放。
+- DDP 下非同步累积 batch 使用 `no_sync()`。
+- checkpoint 文件名仍以 optimizer step 为准。
+- `args.json` 会保存 `grad_accum_steps`。
+- logger 记录 `data_step` 和 `effective_batch_size`。
+
+## 验证 1：兼容原行为
+
+命令要点：
+
+```text
+save_dir: save/interhuman/p3_grad_accum_1_smoke
+num_steps: 2
+grad_accum_steps: 1
+max_samples: 2
+```
+
+结果：
+
+```text
+step[0]: loss[0.67435]
+step[1]: loss[0.62534]
+```
+
+验证：
+
+```text
+args.json grad_accum_steps = 1
+model000000002.pt 可加载，50 keys
+opt000000002.pt 可加载，2 keys
+```
+
+## 验证 2：两步累积
+
+命令要点：
+
+```text
+save_dir: save/interhuman/p3_grad_accum_2_smoke
+num_steps: 2
+grad_accum_steps: 2
+max_samples: 2
+```
+
+结果：
+
+```text
+Starting epoch 0:2
+step[0]: loss[0.64726]
+Starting epoch 1:2
+step[1]: loss[0.62225]
+```
+
+说明：
+
+`max_samples=2` 时 dataloader 每个 epoch 只有 2 个 batch。`num_steps=2` 且 `grad_accum_steps=2` 需要 4 个 data batch，因此正确跨 2 个 epoch 完成 2 个 optimizer steps。
+
+验证：
+
+```text
+args.json grad_accum_steps = 2
+model000000002.pt 可加载，50 keys
+opt000000002.pt 可加载，2 keys
+```
+
+## 下一步
+
+可进入单卡 baseline：
+
+```text
+batch_size: 1
+grad_accum_steps: 16-64
+layers: 4
+latent_dim: 256
+num_steps: 50k
+```
+
+在长训前建议先用：
+
+```text
+num_steps: 1000
+grad_accum_steps: 16
+```
+
+验证显存、速度和 checkpoint 命名。

--- a/docs/ai/context/20260510-101413-interhuman-p3-accum16-smoke.md
+++ b/docs/ai/context/20260510-101413-interhuman-p3-accum16-smoke.md
@@ -1,0 +1,134 @@
+# InterHuman-AS P3 grad_accum=16 中等 smoke 记录
+
+## 目的
+
+验证 P3 梯度累积在更接近单卡 baseline 的设置下是否稳定：
+
+```text
+num_steps = 1000
+grad_accum_steps = 16
+batch_size = 1
+layers = 2
+latent_dim = 128
+```
+
+这里的 `num_steps` 仍表示 optimizer steps，因此本次训练实际执行约：
+
+```text
+1000 * 16 = 16000
+```
+
+个 forward/backward data batch。
+
+## 命令
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+python -m train.train_mdm \
+  --setting cmdm \
+  --save_dir save/interhuman/p3_grad_accum_16_1000_smoke \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --cond_mask_prob 0 \
+  --num_person 2 \
+  --layers 2 \
+  --latent_dim 128 \
+  --num_frames 150 \
+  --arch online \
+  --overwrite \
+  --pose_rep rot6d \
+  --body_model smpl \
+  --train_platform_type NoPlatform \
+  --unconstrained \
+  --batch_size 1 \
+  --grad_accum_steps 16 \
+  --num_steps 1000 \
+  --save_interval 500 \
+  --log_interval 100 \
+  --lambda_orient 0 \
+  --lambda_body 0 \
+  --lambda_transl 0 \
+  --max_samples -1
+```
+
+## 结果
+
+训练自然达到 `num_steps=1000` 并退出，退出码为 0。
+
+耗时：
+
+```text
+7:05.02
+```
+
+资源：
+
+```text
+GPU: RTX 3080 10GB
+训练中显存: 约 1572 MiB
+退出后显存: 137 MiB
+Maximum resident set size: 4155348 KB
+```
+
+loss 记录：
+
+```text
+step[0]:   loss[0.65583]
+step[100]: loss[0.14353]
+step[200]: loss[0.11022]
+step[300]: loss[0.09788]
+step[400]: loss[0.09039]
+step[500]: loss[0.08481]
+step[900]: loss[0.07124]
+```
+
+说明：
+
+- 输出日志中 `tqdm` 的百分比是当前 epoch 内 data batch 进度，不是 optimizer step 进度。
+- 本次跨 3 个 epoch，符合 `ceil(16000 / 6021) = 3`。
+- `save_interval=500` 正常写出 0、500、1000 三组 checkpoint。
+
+## 输出文件
+
+```text
+save/interhuman/p3_grad_accum_16_1000_smoke/args.json
+save/interhuman/p3_grad_accum_16_1000_smoke/model000000000.pt
+save/interhuman/p3_grad_accum_16_1000_smoke/model000000500.pt
+save/interhuman/p3_grad_accum_16_1000_smoke/model000001000.pt
+save/interhuman/p3_grad_accum_16_1000_smoke/opt000000000.pt
+save/interhuman/p3_grad_accum_16_1000_smoke/opt000000500.pt
+save/interhuman/p3_grad_accum_16_1000_smoke/opt000001000.pt
+```
+
+checkpoint 加载验证：
+
+```text
+args.json grad_accum_steps = 16
+args.json batch_size = 1
+args.json num_steps = 1000
+model000000000.pt: OrderedDict, 50 keys
+model000000500.pt: OrderedDict, 50 keys
+model000001000.pt: OrderedDict, 50 keys
+opt000001000.pt: dict, 2 keys
+```
+
+进程状态：
+
+```text
+无残留 train_mdm / micromamba run 进程
+无残留 GPU compute app
+```
+
+## 结论
+
+P3 梯度累积路径可用于后续单卡 baseline。建议下一步进入：
+
+```text
+layers = 4
+latent_dim = 256
+batch_size = 1
+grad_accum_steps = 16 或 32
+num_steps = 50000
+```
+
+如显存仍宽松，可以先试 `grad_accum_steps=32`；如果训练时间过长，先用 `grad_accum_steps=16` 产出可对比 baseline。

--- a/docs/ai/context/20260510-104139-dirty-worktree-cleanup-plan.md
+++ b/docs/ai/context/20260510-104139-dirty-worktree-cleanup-plan.md
@@ -1,0 +1,19 @@
+# 脏工作区整理计划
+
+## 目标
+
+把 P3 之后残留的脏修改按来源拆分，避免后续 InterHuman baseline 训练混入无关文件。
+
+## 处理顺序
+
+1. 保护当前状态：保存当前 dirty diff 摘要，必要时可从 git diff 恢复。
+2. 外部资产和实验输出：更新 `.gitignore`，不提交大文件、模型、结果和本地工具。
+3. README：不直接覆盖官方 `README.md`，改为新建中文文档 `README.zh-CN.md`，再恢复 `README.md`。
+4. 渲染修复：单独验证并提交 `render/*` 的行为修复。
+5. 注释类改动：单独验证并提交 `utils/model_util.py`、`utils/parser_util.py` 以及对应 context 文档。
+
+## 不处理范围
+
+- 不删除本地大文件和实验输出，只通过 `.gitignore` 避免误提交。
+- 不回滚 P3 已提交内容。
+- 不修改 main 分支。

--- a/docs/ai/context/20260510-104532-render-cleanup-validation.md
+++ b/docs/ai/context/20260510-104532-render-cleanup-validation.md
@@ -1,0 +1,59 @@
+# 渲染修复验证记录
+
+## 范围
+
+本次只提交渲染相关修复：
+
+- `render/crendermotion.py`
+- `render/renderer.py`
+
+## 改动
+
+- 将 `torch.permute(vidmeshes, (2, 0, 1))` 改为 tensor 方法 `vidmeshes.permute(2, 0, 1)`。
+- `PYOPENGL_PLATFORM` 使用 `os.environ.setdefault('PYOPENGL_PLATFORM', 'egl')`，避免强制覆盖调用方环境。
+- 渲染输出合成时使用 `rgb[:, :, :3]`，保证与三通道背景图维度一致。
+
+## 验证
+
+语法验证：
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+python -m py_compile render/crendermotion.py render/renderer.py
+```
+
+实际渲染验证：
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+python -m render.crendermotion \
+  --data_path results/chi3d_smoke/results.npy \
+  --num_person 2 \
+  --setting cmdm \
+  --body_model smplx
+```
+
+结果：
+
+```text
+退出码 0
+生成 8 个视频
+```
+
+生成文件：
+
+```text
+results/chi3d_smoke/rendered/Grab_0.mp4
+results/chi3d_smoke/rendered/Handshake_1.mp4
+results/chi3d_smoke/rendered/Hit_2.mp4
+results/chi3d_smoke/rendered/HoldingHands_3.mp4
+results/chi3d_smoke/rendered/Hug_4.mp4
+results/chi3d_smoke/rendered/Kick_5.mp4
+results/chi3d_smoke/rendered/Posing_6.mp4
+results/chi3d_smoke/rendered/Push_7.mp4
+```
+
+说明：
+
+- `results/` 已被 `.gitignore` 忽略，渲染产物不进入提交。
+- ffmpeg 有 macro block size resize warning，不影响本次渲染成功。

--- a/docs/ai/context/20260510-104609-comment-cleanup-validation.md
+++ b/docs/ai/context/20260510-104609-comment-cleanup-validation.md
@@ -1,0 +1,29 @@
+# 注释类改动验证记录
+
+## 范围
+
+本次只提交注释类改动：
+
+- `utils/model_util.py`
+- `utils/parser_util.py`
+- `docs/ai/context/20260509-133206-parser-util-comment-plan.md`
+- `docs/ai/context/20260509-160403-model-util-create-model-diffusion-comments.md`
+
+## 验证
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+python -m py_compile utils/model_util.py utils/parser_util.py
+```
+
+结果：
+
+```text
+退出码 0
+```
+
+## 说明
+
+- 未修改 argparse 参数、默认值或 choices。
+- 未修改模型创建和 diffusion 创建的执行逻辑。
+- 仅补充中文注释，解释关键参数恢复路径和 `create_model_and_diffusion()` 的职责。

--- a/docs/ai/context/20260510-132607-interhuman-paper-config-smoke-plan.md
+++ b/docs/ai/context/20260510-132607-interhuman-paper-config-smoke-plan.md
@@ -1,0 +1,61 @@
+# InterHuman-AS 论文配置小步 smoke 计划
+
+## 目的
+
+在进入长训前，先验证论文模型规模和显式 loss 在单张 RTX 3080 上能否运行。
+
+## 对齐论文的配置
+
+```text
+dataset = interhuman
+setting = online, unconstrained
+num_frames = 150
+layers = 8
+latent_dim = 512
+lambda_orient = 1
+lambda_body = 1
+lambda_transl = 1
+```
+
+## 本次不对齐论文的配置
+
+```text
+num_steps = 100
+batch_size = 1
+grad_accum_steps = 4
+```
+
+原因：
+
+- 本次目标是验证显存、显式 loss 和 checkpoint，不是产出论文指标。
+- 论文训练为 `batch_size=64, num_steps=500000`，单卡 3080 需要先逐级放大。
+
+## 命令要点
+
+```text
+save_dir = save/interhuman/paper_config_l8_d512_loss_smoke
+data_path = dataset/interhuman/smpl/conditioned
+save_interval = 50
+log_interval = 10
+```
+
+## 验收
+
+- 训练达到 `num_steps=100`，退出码 0。
+- loss 有限，不出现 OOM。
+- checkpoint `model000000100.pt` 和 `opt000000100.pt` 可加载。
+- 记录显存峰值和耗时。
+
+## 后续门槛
+
+通过后再运行：
+
+```text
+layers = 8
+latent_dim = 512
+batch_size = 1
+grad_accum_steps = 64
+num_steps = 1000
+```
+
+用于验证论文 effective batch size 64 的单卡可行性。

--- a/docs/ai/context/20260510-132607-interhuman-paper-config-smoke-result.md
+++ b/docs/ai/context/20260510-132607-interhuman-paper-config-smoke-result.md
@@ -1,0 +1,120 @@
+# InterHuman-AS 论文配置小步 smoke 结果
+
+## 目标
+
+验证更接近论文训练设置的模型规模和显式 loss 是否能在单张 RTX 3080 上运行。
+
+## 配置
+
+```text
+dataset = interhuman
+data_path = dataset/interhuman/smpl/conditioned
+setting = cmdm
+arch = online
+unconstrained = true
+body_model = smpl
+pose_rep = rot6d
+num_frames = 150
+layers = 8
+latent_dim = 512
+lambda_orient = 1
+lambda_body = 1
+lambda_transl = 1
+batch_size = 1
+grad_accum_steps = 4
+num_steps = 100
+```
+
+## 首次运行问题
+
+首次运行输出从 `step[0]` 开始为：
+
+```text
+loss[nan]
+```
+
+原因：
+
+`diffusion/gaussian_diffusion.py` 中 explicit translation loss 仍硬编码读取：
+
+```text
+[:, 55:56, 0:3, :]
+```
+
+这适用于旧的 56-slot 表示，但当前 InterHuman H5 是 `[25, 6, T]`，translation 在最后一个 slot，也就是 index `24`。`55:56` 得到空 tensor，`masked_l2()` 中分母为 0，导致 NaN。
+
+修复：
+
+```text
+cmotion[:, -1:, 0:3, :]
+target[:, -1:, 0:3, :]
+model_output[:, -1:, 0:3, :]
+```
+
+该写法同时兼容 56-slot 和 25-slot 表示，因为两者都把 root translation 放在最后一个 slot。
+
+## 修复后验证
+
+输出目录：
+
+```text
+save/interhuman/paper_config_l8_d512_loss_smoke_fixed
+```
+
+结果：
+
+```text
+退出码 = 0
+耗时 = 0:40.76
+最大 CPU RSS = 4216292 KB
+训练中观测显存约 2.4GB
+退出后显存 = 137 MiB
+```
+
+loss 记录：
+
+```text
+step[0]:  loss[0.70100]
+step[10]: loss[0.20821]
+step[20]: loss[0.15965]
+step[30]: loss[0.13664]
+step[40]: loss[0.12742]
+step[50]: loss[0.12056]
+step[60]: loss[0.11777]
+step[70]: loss[0.11527]
+step[80]: loss[0.11294]
+step[90]: loss[0.11064]
+```
+
+checkpoint：
+
+```text
+model000000000.pt: OrderedDict, 158 keys
+model000000050.pt: OrderedDict, 158 keys
+model000000100.pt: OrderedDict, 158 keys
+opt000000100.pt: dict, 2 keys
+```
+
+进程状态：
+
+```text
+无残留 train_mdm / micromamba run 进程
+无残留 GPU compute app
+```
+
+## 结论
+
+论文模型规模 `layers=8, latent_dim=512` 和显式 loss 在 RTX 3080 上可运行。当前还不是论文训练，只是小步 smoke。
+
+下一步建议：
+
+```text
+layers = 8
+latent_dim = 512
+batch_size = 1
+grad_accum_steps = 64
+num_steps = 1000
+lambda_orient/body/transl = 1
+```
+
+该配置用于验证单卡 effective batch size 64 的论文 batch size 近似口径。

--- a/docs/ai/context/20260510-134517-interhuman-paper-batch64-smoke-plan.md
+++ b/docs/ai/context/20260510-134517-interhuman-paper-batch64-smoke-plan.md
@@ -1,0 +1,58 @@
+# InterHuman-AS 论文 batch size 近似 smoke 计划
+
+## 目的
+
+验证单张 RTX 3080 是否能用梯度累积近似论文训练 batch size。
+
+论文训练口径：
+
+```text
+batch_size = 64
+layers = 8
+latent_dim = 512
+lambda_inter = 1
+num_steps = 500000
+```
+
+本次 smoke：
+
+```text
+batch_size = 1
+grad_accum_steps = 64
+effective_batch_size = 64
+layers = 8
+latent_dim = 512
+lambda_orient/body/transl = 1
+num_steps = 1000
+```
+
+说明：
+
+- `num_steps` 表示 optimizer steps。
+- 本次实际需要约 `1000 * 64 = 64000` 个 forward/backward data batch。
+- 本次仍不是论文长训，只验证 batch size 近似口径、速度、checkpoint 和自然退出。
+
+## 命令要点
+
+```text
+save_dir = save/interhuman/paper_config_l8_d512_accum64_1000_smoke
+save_interval = 500
+log_interval = 100
+```
+
+## 预估
+
+基于 `grad_accum_steps=4, num_steps=100` 的耗时 `40.76s`，本次粗估：
+
+```text
+40.76s * (64000 / 400) = 6521.6s = 108.7min
+```
+
+实际速度可能因 checkpoint I/O 和调度波动变化。
+
+## 验收
+
+- 训练达到 `num_steps=1000`，退出码 0。
+- loss 有限。
+- checkpoint `model000001000.pt` 和 `opt000001000.pt` 可加载。
+- 无残留训练进程和 GPU compute app。

--- a/docs/ai/context/20260510-150302-interhuman-paper-batch64-smoke-result.md
+++ b/docs/ai/context/20260510-150302-interhuman-paper-batch64-smoke-result.md
@@ -1,0 +1,90 @@
+# InterHuman-AS 论文 batch size 近似 smoke 结果
+
+## 结论
+
+通过。
+
+本次 run 用单张 RTX 3080 通过梯度累积近似论文 batch size：
+
+```text
+layers = 8
+latent_dim = 512
+batch_size = 1
+grad_accum_steps = 64
+effective_batch_size = 64
+num_steps = 1000
+lambda_orient = 1
+lambda_body = 1
+lambda_transl = 1
+```
+
+这仍然只是论文配置口径的 1000 optimizer step smoke，不是论文 500K step 长训，也不是完整 Table 4 评估。
+
+## 训练结果
+
+- save_dir：`save/interhuman/paper_config_l8_d512_accum64_1000_smoke`
+- 退出码：0
+- wall time：`1:16:09`
+- 最大 RSS：`4243284 KB`
+- GPU 显存训练中约 `2396 MiB / 10240 MiB`
+- 训练后 GPU 显存约 `137 MiB / 10240 MiB`
+
+已写出 checkpoint：
+
+```text
+model000000000.pt
+opt000000000.pt
+model000000500.pt
+opt000000500.pt
+model000001000.pt
+opt000001000.pt
+```
+
+已捕获的 loss：
+
+```text
+step[0]: loss[0.67129]
+step[100]: loss[0.10378]
+```
+
+后续 step 日志被 tqdm 进度条密集输出截断，未完整保留；checkpoint 和退出码作为本次 smoke 的主要验收依据。
+
+## 验证
+
+参数核对结果：
+
+```text
+layers=8
+latent_dim=512
+batch_size=1
+grad_accum_steps=64
+num_steps=1000
+lambda_orient=1.0
+lambda_body=1.0
+lambda_transl=1.0
+```
+
+checkpoint 加载结果：
+
+```text
+model000000000.pt: OrderedDict len=158
+model000000500.pt: OrderedDict len=158
+model000001000.pt: OrderedDict len=158
+opt000001000.pt: dict len=2
+```
+
+残留检查：
+
+- 训练进程已自然退出。
+- 后续 `ps` 检查只命中检查命令本身，没有残留训练进程。
+
+## 影响
+
+已确认当前单卡可以跑论文模型尺寸和有效 batch size 64 的 InterHuman H5 训练 smoke。下一步可以进入更长 baseline 训练，但这仍然不能替代以下复现缺口：
+
+- 论文 500K optimizer steps 长训。
+- InterHuman 专用生成流程：test-conditioned actor -> generated reactor。
+- DDIM-5 生成口径。
+- ST-GCN recognition evaluator 和 recognition checkpoint。
+- InterHuman 类别标签来源。
+- SMPL-X 口径确认；当前仍是 SMPL reproduction attempt。

--- a/docs/ai/context/20260510-193303-interhuman-50k-baseline-plan.md
+++ b/docs/ai/context/20260510-193303-interhuman-50k-baseline-plan.md
@@ -1,0 +1,119 @@
+# InterHuman-AS 50K baseline 训练计划
+
+## 目标
+
+进入论文配置口径的更长 baseline 训练，验证在单张 RTX 3080 上：
+
+- 论文模型尺寸能否长时间稳定训练。
+- 有效 batch size 64 的梯度累积是否能稳定保存和恢复。
+- loss 是否在 50K optimizer steps 内保持有限且无明显训练崩溃。
+
+本阶段仍不是论文 1:1 复现，因为论文训练为 500K steps，且 Table 4 还缺 ST-GCN recognition evaluator、InterHuman 类别标签来源、DDIM-5 生成流程和 SMPL-X 口径确认。
+
+## 训练配置
+
+```text
+dataset = interhuman
+data_path = dataset/interhuman/smpl/conditioned
+body_model = smpl
+pose_rep = rot6d
+num_person = 2
+num_frames = 150
+layers = 8
+latent_dim = 512
+batch_size = 1
+grad_accum_steps = 64
+effective_batch_size = 64
+num_steps = 50000
+save_interval = 5000
+log_interval = 100
+lambda_orient = 1
+lambda_body = 1
+lambda_transl = 1
+```
+
+保存目录：
+
+```text
+save/interhuman/paper_config_l8_d512_accum64_50000_baseline
+```
+
+日志：
+
+```text
+save/interhuman/paper_config_l8_d512_accum64_50000_baseline/train.log
+```
+
+## 预估
+
+上一阶段 `num_steps=1000, grad_accum_steps=64` 实测耗时：
+
+```text
+1:16:09 = 4569s
+```
+
+50K baseline 粗估：
+
+```text
+4569s * 50 = 228450s = 63.46h = 2.64 days
+```
+
+checkpoint 大小约：
+
+```text
+model checkpoint ~= 111MB
+optimizer checkpoint ~= 203MB
+每次保存合计 ~= 314MB
+```
+
+`save_interval=5000` 时预计保存 `0, 5000, ..., 50000` 共 11 组，约 `3.5GB`，当前磁盘空间足够。
+
+## 启动方式
+
+由于训练预计超过 2 天，本次用 detached 进程启动，不在交互 session 里等待完整训练结束。
+
+核心命令：
+
+```text
+/usr/bin/time -v micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet \
+  python -m train.train_mdm \
+  --setting cmdm \
+  --save_dir save/interhuman/paper_config_l8_d512_accum64_50000_baseline \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --cond_mask_prob 0 \
+  --num_person 2 \
+  --layers 8 \
+  --latent_dim 512 \
+  --num_frames 150 \
+  --arch online \
+  --overwrite \
+  --pose_rep rot6d \
+  --body_model smpl \
+  --train_platform_type NoPlatform \
+  --unconstrained \
+  --batch_size 1 \
+  --grad_accum_steps 64 \
+  --num_steps 50000 \
+  --save_interval 5000 \
+  --log_interval 100 \
+  --lambda_orient 1 \
+  --lambda_body 1 \
+  --lambda_transl 1 \
+  --max_samples -1
+```
+
+## 验收
+
+- 后台进程启动并进入训练 loop。
+- `args.json`、`model000000000.pt`、`opt000000000.pt` 写出。
+- 初始 checkpoint 可加载。
+- `step[0]` 或早期 loss 为有限值。
+- GPU 显存保持在 10GB 内。
+- 中途保存 `model000005000.pt` 后再记录一次状态。
+
+## 风险
+
+- 单卡预计训练 2.6 天，期间 GPU 被长时间占用。
+- 若系统重启或进程被杀，需要从最近的 `model*.pt` 和 `opt*.pt` 恢复。
+- 当前训练日志使用 tqdm，长日志较大但可接受。

--- a/docs/ai/context/20260510-193731-interhuman-50k-baseline-started.md
+++ b/docs/ai/context/20260510-193731-interhuman-50k-baseline-started.md
@@ -1,0 +1,97 @@
+# InterHuman-AS 50K baseline 已启动
+
+## 状态
+
+已启动 detached 长训进程。
+
+```text
+save_dir = save/interhuman/paper_config_l8_d512_accum64_50000_baseline
+log = save/interhuman/paper_config_l8_d512_accum64_50000_baseline/train.log
+pid_file = save/interhuman/paper_config_l8_d512_accum64_50000_baseline/train.pid
+launcher_pid = 150767
+start_time = 2026-05-10T19:36:21+09:00
+```
+
+启动方式改为 `setsid -f`，原因是本环境会清理普通后台子进程，`nohup ... &` 无法保活训练。
+
+## 启动验收
+
+训练已进入 loop：
+
+```text
+Starting epoch 0:532
+step[0]: loss[0.67129]
+saving model...
+```
+
+GPU 状态：
+
+```text
+memory.used = 2396 MiB
+memory.total = 10240 MiB
+utilization.gpu = 43%
+power.draw = 103.31 W
+```
+
+已写出初始文件：
+
+```text
+args.json
+model000000000.pt
+opt000000000.pt
+train.log
+train.pid
+```
+
+初始 checkpoint 验证：
+
+```text
+layers=8
+latent_dim=512
+batch_size=1
+grad_accum_steps=64
+num_steps=50000
+save_interval=5000
+log_interval=100
+lambda_orient=1.0
+lambda_body=1.0
+lambda_transl=1.0
+model000000000.pt: OrderedDict len=158
+opt000000000.pt: dict len=2
+```
+
+## 监控命令
+
+查看进程：
+
+```bash
+pid=$(cat save/interhuman/paper_config_l8_d512_accum64_50000_baseline/train.pid)
+ps -p "$pid" -o pid,ppid,sid,stat,etime,%cpu,%mem,cmd
+ps --ppid "$pid" -o pid,ppid,stat,etime,%cpu,%mem,cmd
+```
+
+查看日志：
+
+```bash
+tail -n 80 save/interhuman/paper_config_l8_d512_accum64_50000_baseline/train.log
+```
+
+查看 checkpoint：
+
+```bash
+find save/interhuman/paper_config_l8_d512_accum64_50000_baseline -maxdepth 1 -type f -name 'model*.pt' -o -name 'opt*.pt'
+```
+
+查看 GPU：
+
+```bash
+nvidia-smi --query-gpu=index,memory.used,memory.total,utilization.gpu,power.draw --format=csv,noheader,nounits
+```
+
+## 后续
+
+下一次检查重点：
+
+- 是否到达 `step[100]` 并保持有限 loss。
+- 是否持续接近 14 micro-batch/s。
+- 是否按计划在 `model000005000.pt` / `opt000005000.pt` 写出后继续训练。

--- a/docs/ai/context/20260510-195110-interhuman-50k-baseline-step100.md
+++ b/docs/ai/context/20260510-195110-interhuman-50k-baseline-step100.md
@@ -1,0 +1,30 @@
+# InterHuman-AS 50K baseline step[100] 检查
+
+## 结论
+
+50K baseline 已通过早期 `step[100]` 检查。
+
+日志中已出现：
+
+```text
+step[0]: loss[0.67129]
+step[100]: loss[0.10378]
+Starting epoch 2:532
+```
+
+说明：
+
+- 训练已跨过 epoch 0 和 epoch 1，进入 epoch 2。
+- early loss 为有限值。
+- `step[100]` loss 与上一轮 1000-step batch64 smoke 中捕获到的 `0.10378` 一致。
+- 后台训练仍应继续运行到 `num_steps=50000`，下一关键 checkpoint 是 `model000005000.pt` / `opt000005000.pt`。
+
+## 后续监控
+
+下一次重点检查：
+
+```bash
+find save/interhuman/paper_config_l8_d512_accum64_50000_baseline -maxdepth 1 -type f -name 'model000005000.pt' -o -name 'opt000005000.pt'
+tail -n 80 save/interhuman/paper_config_l8_d512_accum64_50000_baseline/train.log
+nvidia-smi --query-gpu=index,memory.used,memory.total,utilization.gpu,power.draw --format=csv,noheader,nounits
+```

--- a/docs/ai/context/20260603-092325-dataset-inventory.md
+++ b/docs/ai/context/20260603-092325-dataset-inventory.md
@@ -1,0 +1,35 @@
+# 数据集清点记录
+
+## 结论
+
+ReGenNet 主项目 README 的正式动作-反应数据集是三套：
+
+- NTU RGB+D 120 / NTU120-AS
+- Chi3D
+- InterHuman / InterHuman-AS
+
+本地当前实际落盘的数据集目录只有两套：
+
+- `dataset/chi3d`
+- `dataset/interhuman`
+
+因此，如果目标是补齐 README 主线三套数据集，本地还缺：
+
+- `dataset/ntu120` 对应的 NTU RGB+D 120 / NTU120-AS 处理后数据
+
+## 依据
+
+- `README.zh-CN.md` 的“数据准备”只列出 `NTU RGB+D 120`、`Chi3D`、`InterHuman`。
+- `dataset/` 当前只有 `chi3d` 和 `interhuman` 两个数据集目录。
+- `dataset/chi3d/smplx/conditioned/` 下已有 `chi3d_smplx_train.h5` 和 `chi3d_smplx_test.h5`。
+- `dataset/interhuman/smpl/conditioned/` 下已有 `interhuman_train.h5`、`interhuman_val.h5`、`interhuman_test.h5` 和 `meta.json`。
+- `data_loaders/get_data.py` 还保留 `humanact12`、`uestc`、`amass` 等上游兼容入口，但这些不是 README 数据准备主线中的三套 ReGenNet 动作-反应数据集。
+
+## 注意
+
+如果问题中的“还需要哪两个”指的是代码兼容入口而不是 README 主线，则额外缺本地数据目录的是：
+
+- `dataset/HumanAct12Poses`
+- `dataset/uestc`
+
+但它们更像上游 MDM/ACTOR 单人动作生成兼容数据集，不是 ReGenNet 动作-反应主实验三件套。

--- a/docs/ai/context/20260603-102909-interhuman-research-direction-from-note.md
+++ b/docs/ai/context/20260603-102909-interhuman-research-direction-from-note.md
@@ -1,0 +1,166 @@
+# InterHuman 后续研究方向推断
+
+## 输入线索
+
+`docs/note.md` 记录：
+
+```text
+MSE 评价指标
+frame number 前20%帧数作为观测数据，预测后80%的双人动作
+关节数 维度
+动作标签或者自然语言的条件
+```
+
+## 判断
+
+导师大概率不是只要求继续做 ReGenNet Table 4 的 1:1 复现，而是建议把当前工程转成一个更明确、可控、可投稿的任务：
+
+```text
+给定双人交互动作序列前 20% 帧，预测后 80% 帧的双人未来动作。
+```
+
+核心任务更接近：
+
+```text
+two-person human interaction motion forecasting
+interaction-aware future motion prediction
+conditioned two-person motion prediction
+```
+
+这和当前 ReGenNet 的 actor-conditioned reaction generation 有关系，但评价口径更简单：优先用 MSE/MPJPE 类重建误差，而不是先卡在 Table 4 的 ST-GCN evaluator、类别标签、recognition checkpoint 和 SMPL-X 口径。
+
+## 最可能的投稿方向
+
+### 方向 A：双人交互动作未来预测基准
+
+定义输入输出：
+
+```text
+input:  前 20% 帧，包含 person A 和 person B
+output: 后 80% 帧，预测 person A 和 person B
+metric: MSE / MPJPE / root translation error / rotation error
+```
+
+优点：
+
+- 和导师笔记完全一致。
+- 不依赖 InterHuman-AS Table 4 的 recognition checkpoint。
+- 当前 H5 loader 和训练链路可以复用。
+- 容易做 ablation：是否使用交互 loss、是否使用文本或动作标签、不同观测比例。
+
+风险：
+
+- 只用 MSE 容易被认为贡献偏工程，需要有模型创新或任务设定创新。
+
+### 方向 B：条件增强的双人动作预测
+
+在方向 A 基础上加入条件：
+
+```text
+condition 1: action label
+condition 2: natural language caption
+condition 3: actor/reactor role
+```
+
+问题定义：
+
+```text
+observe first 20% frames + condition -> predict future 80% two-person motion
+```
+
+优点：
+
+- 能把 InterHuman 的文本优势用起来。
+- 比单纯 MSE 预测更像一篇生成/多模态论文。
+- 可以比较无条件、动作标签条件、自然语言条件三种设置。
+
+风险：
+
+- 当前本地数据还没有 text/caption 目录，需要补数据。
+- 如果只有 action label，没有自然语言，也可以先做弱条件版本。
+
+### 方向 C：在线反应预测
+
+更贴近 ReGenNet：
+
+```text
+input: actor 前 20% 或 actor 当前/历史动作
+output: reactor 后 80% 反应动作
+```
+
+或者：
+
+```text
+input: 双人前 20% + actor 后续动作
+output: reactor 后续动作
+```
+
+优点：
+
+- 和 ReGenNet 的 action-reaction synthesis 对齐。
+- 任务有明确应用意义：一个人的动作触发另一个人的反应。
+
+风险：
+
+- 如果预测目标只包含 reactor，和 note 中“预测后80%的双人动作”不完全一致。
+- online 设置需要严格定义模型可见哪些未来信息。
+
+## 推荐路线
+
+最稳妥路线是：
+
+```text
+先做方向 A，保证能完整训练、评估、画图；
+再扩展方向 B，把 action label 或 natural language 作为条件；
+最后把 ReGenNet 作为 baseline 或 backbone，而不是把论文复现当成最终目标。
+```
+
+建议论文题目方向：
+
+```text
+Conditioned Forecasting of Two-Person Interactive Human Motion
+Interaction-Aware Future Motion Prediction from Partial Dyadic Observations
+Language/Action Conditioned Two-Person Motion Forecasting
+```
+
+## 当前项目需要转向的工作
+
+1. 明确定义 forecasting dataset：
+   - 输入帧：前 20%。
+   - 预测帧：后 80%。
+   - 人数：2。
+   - 表示：SMPL rot6d + root translation 或 joint xyz。
+
+2. 新增 forecasting loader：
+   - 从 H5 读取完整序列。
+   - 输出 `obs_motion` 和 `target_motion`。
+   - 记录 `joint_count`、`feature_dim`、`obs_len`、`pred_len`。
+
+3. 新增简单 baseline：
+   - zero velocity / repeat last frame。
+   - GRU/Transformer deterministic predictor。
+   - ReGenNet/diffusion predictor。
+
+4. 新增 MSE 类评估：
+   - 全局 MSE。
+   - rotation MSE。
+   - translation MSE。
+   - MPJPE，如果可转 joint xyz。
+   - 按时间段报告，例如短期、中期、长期。
+
+5. 再考虑条件：
+   - action label 来源。
+   - natural language caption 来源。
+   - 是否把 condition 作为文本 embedding 或类别 embedding。
+
+## 和当前 ReGenNet 复现的关系
+
+当前 InterHuman Table 4 复现不是白做，它可以作为：
+
+- 数据预处理基础。
+- InterHuman H5 冻结格式。
+- 生成模型 backbone。
+- interaction loss baseline。
+- 论文 related work 和 baseline。
+
+但如果目标是发论文，下一步不应该继续只追 Table 4 1:1 复现。更合适的是把复现结果转化为一个新的、可评估的 forecasting 任务。

--- a/docs/ai/context/20260603-104745-dataset-zip-extract-blocked.md
+++ b/docs/ai/context/20260603-104745-dataset-zip-extract-blocked.md
@@ -1,0 +1,60 @@
+# 数据集 zip 解压检查记录
+
+## 用户请求
+
+将 Windows 路径中的 zip 解压到当前项目的数据目录，并判断其中数据是否为当前项目需要的数据。
+
+原始路径：
+
+```text
+C:\Users\yui\Downloads\drive-download-20260603T013120Z-3-001.zip
+```
+
+## 当前检查
+
+当前项目路径：
+
+```text
+/home/rpartx3080/CodeSpace/ReGenNet
+```
+
+尝试映射到 WSL 常见路径：
+
+```text
+/mnt/c/Users/yui/Downloads/drive-download-20260603T013120Z-3-001.zip
+```
+
+结果：
+
+- `/mnt` 下没有 `c` 盘挂载。
+- `/mnt/c/Users/yui/Downloads/drive-download-20260603T013120Z-3-001.zip` 不存在。
+- 在 `/home/rpartx3080`、`/mnt`、`/tmp` 范围内没有找到 `*20260603T013120Z*` 文件。
+
+## 当前数据集状态
+
+`dataset/` 目前可见：
+
+- `dataset/chi3d`
+- `dataset/interhuman`
+
+主项目 README 中三套动作-反应数据集为：
+
+- NTU RGB+D 120 / NTU120-AS
+- Chi3D
+- InterHuman / InterHuman-AS
+
+本地仍缺 `dataset/ntu120`。
+
+## 阻塞原因
+
+目标 zip 文件对当前 Linux 环境不可见，因此不能解压，也不能判断包内数据类型。
+
+## 下一步
+
+需要将 zip 放到当前环境可访问的位置，例如：
+
+```text
+/home/rpartx3080/CodeSpace/ReGenNet/drive-download-20260603T013120Z-3-001.zip
+```
+
+或提供当前 Linux 环境下可访问的真实路径。拿到文件后先执行 `unzip -l` 查看目录结构，再决定是否解压到 `dataset/`，避免覆盖已有 Chi3D / InterHuman 数据。

--- a/docs/ai/context/20260603-110508-ntu-zip-extract-plan.md
+++ b/docs/ai/context/20260603-110508-ntu-zip-extract-plan.md
@@ -1,0 +1,28 @@
+# NTU zip 解压与数据识别计划
+
+## 目标
+
+把 `/home/rpartx3080/CodeSpace/ReGenNet/drive-download-20260603T013120Z-3-001.zip` 解压到当前项目数据目录，并判断其中是否是当前缺失的数据。
+
+## 设计判断
+
+zip 顶层包含：
+
+- `xsub.train.h5`
+- `xsub.test.h5`
+
+这两个文件名与 `README.zh-CN.md` 中 NTU RGB+D 120 / NTU120-AS 训练命令的 `xsub.train.h5` 和采样命令的 `xsub.test.h5` 匹配。
+
+为了让路径与 README 和 ST-GCN 识别模型训练命令一致，解压目标采用：
+
+```text
+dataset/ntu120/smplx/conditioned/
+```
+
+而不是直接放在 `dataset/` 根目录。
+
+## 风险控制
+
+- 使用 `unzip -n`，避免覆盖已有文件。
+- 解压后检查 H5 顶层 key、样本 shape、dtype 和样本数量。
+- 再与 `data_loaders/a2m/feeder.py`、README 路径约定交叉确认数据类型。

--- a/docs/ai/context/20260603-110659-ntu-zip-extract-result.md
+++ b/docs/ai/context/20260603-110659-ntu-zip-extract-result.md
@@ -1,0 +1,55 @@
+# NTU zip 解压与数据识别结果
+
+## 解压结果
+
+已将：
+
+```text
+/home/rpartx3080/CodeSpace/ReGenNet/drive-download-20260603T013120Z-3-001.zip
+```
+
+解压到：
+
+```text
+dataset/ntu120/smplx/conditioned/
+```
+
+生成文件：
+
+- `dataset/ntu120/smplx/conditioned/xsub.train.h5`
+- `dataset/ntu120/smplx/conditioned/xsub.test.h5`
+
+## H5 检查
+
+`xsub.train.h5`：
+
+- 样本数：4273
+- key 示例：`S001C001P001R001A001`
+- 样本 shape 示例：`(74, 56, 6)`
+- dtype：`float32`
+- 动作编号范围：`A001` 到 `A026`
+- 帧数范围：18 到 203
+
+`xsub.test.h5`：
+
+- 样本数：3845
+- key 示例：`S001C001P003R001A001`
+- 样本 shape 示例：`(83, 56, 6)`
+- dtype：`float32`
+- 动作编号范围：`A001` 到 `A026`
+- 帧数范围：17 到 174
+
+## 判断
+
+这是 NTU RGB+D 120 / NTU120-AS 的双人交互 SMPL-X H5 数据。
+
+依据：
+
+- 文件名 `xsub.train.h5`、`xsub.test.h5` 与 README 中 NTU 训练/采样命令一致。
+- 样本 key 使用 NTU 标准命名格式 `SxxxCxxxPxxxRxxxAxxx`。
+- 动作编号覆盖 `A001` 到 `A026`，与项目 `data_loaders/a2m/feeder.py` 中 `ntu` 双人动作枚举的 26 类一致。
+- 样本 shape 为 `[T, 56, 6]`，符合本项目 NTU/Chi3D SMPL-X feeder 的读取方式。
+
+因此，如果目标是补齐 ReGenNet README 主线三套数据集，这是当前缺失的 NTU120-AS 数据，是需要的数据。
+
+如果目标是补代码兼容入口里的 `HumanAct12Poses` 或 `UESTC`，则这个 zip 不是那两个数据集。

--- a/docs/ai/context/20260603-153629-forecasting-dataset-choice.md
+++ b/docs/ai/context/20260603-153629-forecasting-dataset-choice.md
@@ -1,0 +1,177 @@
+# 双人未来预测数据集选择
+
+## 当前任务
+
+当前阶段选择：
+
+```text
+给定双人动作前 20% 帧，预测后 80% 帧。
+```
+
+暂不继续追 ReGenNet Table 4 完整复现，也暂不做自然语言或动作标签条件预测。
+
+## 本地三套数据状态
+
+### NTU120-AS
+
+路径：
+
+```text
+dataset/ntu120/smplx/conditioned/xsub.train.h5
+dataset/ntu120/smplx/conditioned/xsub.test.h5
+```
+
+统计：
+
+```text
+train: 4273
+test: 3845
+shape: [T, 56, 6]
+train frame min/mean/median/max: 18 / 59.17 / 57 / 203
+test  frame min/mean/median/max: 17 / 53.24 / 49 / 174
+```
+
+优势：
+
+- SMPL-X 表示，和 ReGenNet 原始 NTU/Chi3D 路径一致。
+- 有 26 类双人动作类别，可做后续 action-conditioned forecasting。
+- 本地已有 `recognition_training/ntu_smplx/checkpoint_0100.pth.tar`。
+- 样本数较大，数据形态规整。
+
+不足：
+
+- 序列偏短，README 训练口径是 60 帧；前 20% 只有约 12 帧，后 80% 约 48 帧。
+- 动作类别更偏 RGB-D action recognition，交互丰富度不如 InterHuman。
+
+### Chi3D
+
+路径：
+
+```text
+dataset/chi3d/smplx/conditioned/chi3d_smplx_train.h5
+dataset/chi3d/smplx/conditioned/chi3d_smplx_test.h5
+```
+
+统计：
+
+```text
+train: 293
+test: 74
+shape: [T, 56, 6]
+train frame min/mean/median/max: 105 / 171.86 / 170 / 346
+test  frame min/mean/median/max: 111 / 179.54 / 180 / 317
+```
+
+优势：
+
+- SMPL-X 表示，和原项目路径一致。
+- 长度适合前 20% 到后 80% 的预测设定。
+- 本地已有 `recognition_training/chi3d_smplx/checkpoint_0060.pth.tar`。
+
+不足：
+
+- 样本太少，单独作为主数据集发论文风险高。
+- 更适合作为小规模验证或跨数据集补充实验。
+
+### InterHuman
+
+路径：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+```
+
+统计：
+
+```text
+train: 6021
+val: 580
+test: 1175
+shape: [T, 25, 12]
+train frame min/mean/median/max: 6 / 283.08 / 144 / 8231
+val   frame min/mean/median/max: 9 / 326.73 / 115 / 5154
+test  frame min/mean/median/max: 6 / 301.19 / 124 / 9097
+```
+
+优势：
+
+- 样本数最大。
+- 序列平均长度最长，最适合“前 20% 观测，后 80% 预测”。
+- 数据语义更接近双人交互动作。
+- 当前项目已经为 InterHuman 实现 H5 预处理和 loader，并完成多个 smoke。
+
+不足：
+
+- 当前本地是 SMPL 25-slot 表示，不是 NTU/Chi3D 的 SMPL-X 56-slot 表示。
+- 本地没有 text/caption 目录，暂时不能做自然语言条件。
+- 没有 InterHuman recognition checkpoint；但当前 forecasting 阶段以 MSE 类指标为主，不依赖该 checkpoint。
+- 帧长分布很宽，需要在 forecasting loader 中明确最小帧数、裁剪和采样策略。
+
+## 推荐选择
+
+主数据集：
+
+```text
+InterHuman
+```
+
+理由：
+
+```text
+InterHuman 最大、最长、交互语义最匹配当前 forecasting 任务，并且本地已有可用 H5 链路。
+```
+
+辅助数据集：
+
+```text
+NTU120-AS
+```
+
+用途：
+
+```text
+后续做 action label 条件预测，或作为更规整的 SMPL-X 对照实验。
+```
+
+不建议作为主数据集：
+
+```text
+Chi3D
+```
+
+理由：
+
+```text
+样本量太小，不适合作为第一阶段主线；可作为 qualitative 或 cross-dataset generalization 补充。
+```
+
+## 当前边界
+
+第一阶段只做：
+
+```text
+InterHuman unconditioned two-person forecasting
+input:  前 20% 双人动作
+target: 后 80% 双人动作
+metric: MSE / rotation MSE / translation MSE
+```
+
+暂不做：
+
+```text
+Table 4 复现
+自然语言条件预测
+动作标签条件预测
+SMPL-X 转换
+ST-GCN recognition evaluator
+```
+
+后续如果第一阶段稳定，再考虑：
+
+```text
+NTU120-AS action-conditioned forecasting
+Chi3D 小规模泛化验证
+InterHuman 文本数据补齐后的 language-conditioned forecasting
+```

--- a/docs/ai/context/20260603-154341-interaction-relation-network-direction.md
+++ b/docs/ai/context/20260603-154341-interaction-relation-network-direction.md
@@ -1,0 +1,198 @@
+# 双人关系推理网络方向
+
+## 背景
+
+当前任务边界：
+
+```text
+InterHuman
+输入：双人前 20% 动作
+输出：双人后 80% 动作
+暂不加入自然语言条件
+暂不追 ReGenNet Table 4
+```
+
+用户补充的方向：
+
+```text
+用一个神经网络去思考这两个人之间的关系。
+```
+
+## 判断
+
+这是比“加入自然语言条件”更合理的论文创新点。原因是它和自动驾驶、机器人、人机共处、行人交互预测等后续应用一致：
+
+```text
+真实系统可观察到两个人的历史姿态、距离、朝向、速度和交互趋势；
+真实系统通常不会提前获得自然语言描述。
+```
+
+因此创新点应从可观测交互关系中学习，而不是依赖 oracle 文本。
+
+## 关系推理网络要学习什么
+
+可以显式建模以下关系：
+
+```text
+相对位置：person A root - person B root
+相对速度：person A velocity - person B velocity
+相对朝向：root orientation difference
+身体距离：关键关节间距离或最小距离
+交互阶段：靠近、接触、远离、同步、对抗
+影响方向：A 影响 B、B 影响 A、双向影响
+```
+
+这些关系不需要人工标签，可以从前 20% 观测动作中自监督提取。
+
+## 可行模型形式
+
+### 方案 1：Relation Encoder
+
+在 forecasting 模型前增加一个关系编码器：
+
+```text
+obs_motion -> relation_encoder -> relation_embedding
+obs_motion + relation_embedding -> future_predictor
+```
+
+优点：
+
+- 实现最简单。
+- 容易做 ablation：去掉 relation encoder 看性能下降。
+- 适合第一版。
+
+### 方案 2：Person Graph / Joint Graph
+
+把两个人建成图：
+
+```text
+节点：关节或人
+边：人体骨架边 + 跨人交互边
+```
+
+跨人边可以由距离、注意力或可学习权重决定。
+
+优点：
+
+- 更像“神经网络思考两人关系”。
+- 可解释性更强，可以可视化 cross-person attention。
+
+风险：
+
+- 工程量更大。
+- 如果设计太复杂，第一版容易失控。
+
+### 方案 3：Cross-Attention Interaction Module
+
+分别编码 person A 和 person B，然后做双向 cross-attention：
+
+```text
+A_obs -> A_tokens
+B_obs -> B_tokens
+A attends to B
+B attends to A
+interaction_tokens -> future predictor
+```
+
+优点：
+
+- 和 Transformer/diffusion backbone 容易结合。
+- 能表达非对称影响关系。
+
+风险：
+
+- 需要设计清楚 token 粒度：按人、按关节、按时间，或三者组合。
+
+## 推荐第一版
+
+第一版建议采用：
+
+```text
+Relation Encoder + Future Predictor
+```
+
+不要一开始做过大的图网络。最小可行关系特征：
+
+```text
+root relative translation
+root relative velocity
+root orientation difference
+inter-person joint distance summary
+```
+
+然后用一个小 Transformer/MLP/GRU 编码成：
+
+```text
+relation_embedding
+```
+
+再注入 forecasting 模型。
+
+## 论文表述
+
+主张不应写成：
+
+```text
+我们额外加入一个条件。
+```
+
+而应写成：
+
+```text
+双人未来动作预测的关键不是单人运动外推，而是对两人交互关系的动态建模。
+```
+
+可验证假设：
+
+```text
+显式建模双人关系可以降低长期预测误差，并改善交互一致性。
+```
+
+## 实验设计
+
+至少需要比较：
+
+```text
+Baseline 1: repeat last frame
+Baseline 2: no-relation forecasting model
+Ours: relation-aware forecasting model
+```
+
+指标：
+
+```text
+future MSE
+rotation MSE
+translation MSE
+long-horizon MSE
+relative distance error
+collision / penetration proxy
+diversity 或 best-of-K，若后续做多模态预测
+```
+
+核心 ablation：
+
+```text
+去掉 relation encoder
+只用 person A
+只用 person B
+使用双人但不使用跨人关系
+不同观测比例：10% / 20% / 30% / 50%
+```
+
+## 当前结论
+
+当前论文方向应修正为：
+
+```text
+Interaction-aware two-person human motion forecasting
+```
+
+第一阶段实现边界：
+
+```text
+InterHuman
+前 20% 双人动作 -> 后 80% 双人动作
+先建立 no-relation baseline
+再加入 relation encoder
+```

--- a/docs/ai/context/20260603-154759-joint-interaction-forecasting-boundary.md
+++ b/docs/ai/context/20260603-154759-joint-interaction-forecasting-boundary.md
@@ -1,0 +1,123 @@
+# 联合交互预测边界
+
+## 核心判断
+
+双人未来动作预测不应定义为：
+
+```text
+person A 单独预测未来
+person B 单独预测未来
+最后把两个结果拼在一起
+```
+
+更合理的定义是：
+
+```text
+两个人组成一个相互影响的动态系统，模型需要联合预测两个人的未来。
+```
+
+## 研究问题表述
+
+当前主线应表述为：
+
+```text
+Interaction-aware joint forecasting of two-person human motion.
+```
+
+中文：
+
+```text
+交互感知的双人动作联合未来预测。
+```
+
+重点不是预测两个独立个体，而是建模：
+
+```text
+A 如何影响 B
+B 如何影响 A
+两个人的相对位置、速度、朝向和身体关系如何共同决定未来动作
+```
+
+## 对模型设计的约束
+
+后续模型不能只做两个独立分支：
+
+```text
+A_obs -> A_future
+B_obs -> B_future
+```
+
+至少需要一个跨人交互模块：
+
+```text
+A_obs, B_obs -> relation_module -> interaction_tokens
+A_obs, B_obs, interaction_tokens -> A_future, B_future
+```
+
+可接受的最小结构：
+
+```text
+obs_two_person_motion
+  -> person encoder
+  -> relation encoder / cross-attention / interaction graph
+  -> joint future decoder
+  -> future_two_person_motion
+```
+
+## Baseline 设计
+
+为了证明“联合交互建模”有意义，实验必须包含：
+
+```text
+Independent baseline:
+分别预测 A 和 B，再拼接。
+
+Concat baseline:
+直接拼接 A/B 历史动作，但没有显式 relation module。
+
+Relation-aware model:
+加入关系推理模块，联合预测 A/B。
+```
+
+如果 relation-aware model 不能明显优于 independent / concat baseline，则论文主张不成立。
+
+## 指标要求
+
+不能只看单人姿态 MSE。还需要能反映交互关系的指标：
+
+```text
+future MSE
+rotation MSE
+translation MSE
+relative root distance error
+relative orientation error
+inter-person distance consistency
+long-horizon error
+```
+
+后续如果做多模态预测，再加入：
+
+```text
+best-of-K error
+diversity
+coverage
+```
+
+## 当前边界
+
+第一阶段实现目标：
+
+```text
+InterHuman
+输入：前 20% 双人动作
+输出：后 80% 双人动作
+模型：先做 no-relation baseline，再做 relation-aware joint predictor
+```
+
+不做：
+
+```text
+把 A/B 分别预测后简单拼接作为最终模型
+自然语言条件
+ReGenNet Table 4 完整复现
+```

--- a/docs/ai/context/20260603-155738-paper-final-goal-draft.md
+++ b/docs/ai/context/20260603-155738-paper-final-goal-draft.md
@@ -1,0 +1,215 @@
+# 论文最终目标草案
+
+## 本轮输入
+
+- 用户指定核心文档：`20260603-154759-joint-interaction-forecasting-boundary.md`。
+- 导师笔记线索：MSE 指标；前 20% 帧作为观测；预测后 80% 双人动作；关注关节数和维度；动作标签或自然语言可作为条件。
+- 当前工程资产：InterHuman / NTU120-AS / Chi3D H5 均已落盘；InterHuman H5 和 ReGenNet 训练链路已有 smoke 和 50K baseline 训练。
+
+## 建议锁定的论文目标
+
+最终目标应定义为：
+
+```text
+Interaction-aware joint forecasting of two-person human motion from partial observations.
+```
+
+中文表述：
+
+```text
+基于部分观测的交互感知双人动作联合未来预测。
+```
+
+核心问题：
+
+```text
+给定一段双人交互动作的前 20% 观测，联合预测两个人后 80% 的未来动作。
+```
+
+关键点是“联合预测”和“交互关系建模”，不是：
+
+```text
+person A 独立预测未来
+person B 独立预测未来
+最后拼接结果
+```
+
+## 必须补上的窗口协议
+
+`前 20% / 后 80%` 不应直接作用在 InterHuman 原始全长序列上。当前 InterHuman 长度分布极宽，最长超过 9000 帧，直接预测全序列会让任务定义不可控。
+
+第一阶段建议使用固定窗口：
+
+```text
+InterHuman main protocol:
+window_len = 150
+obs_len = 30
+pred_len = 120
+input = 前 30 帧双人动作
+target = 后 120 帧双人动作
+```
+
+采样建议：
+
+```text
+训练：从长度 >= 150 的序列中随机裁剪连续 150 帧窗口。
+验证/测试：使用确定性中心裁剪或固定多窗口策略。
+太短序列：第一阶段过滤，不用 padding 伪造未来。
+```
+
+本地长度统计：
+
+```text
+InterHuman train: 6021 条，长度 >=150 的有 2910 条。
+InterHuman val:   580 条，长度 >=150 的有 226 条。
+InterHuman test:  1175 条，长度 >=150 的有 508 条。
+```
+
+NTU120-AS 序列短，不适合 150 帧主协议；如果用于辅助实验，应采用：
+
+```text
+window_len = 60
+obs_len = 12
+pred_len = 48
+```
+
+## 第一阶段主线
+
+主数据集：
+
+```text
+InterHuman
+```
+
+主任务：
+
+```text
+unconditioned two-person joint forecasting
+```
+
+主模型路线：
+
+```text
+obs_two_person_motion
+  -> person/motion encoder
+  -> relation encoder
+  -> joint future predictor
+  -> future_two_person_motion
+```
+
+第一版 relation encoder 不要过大，先建模：
+
+```text
+root relative translation
+root relative velocity
+root orientation difference
+inter-person joint distance summary
+```
+
+## 必须实验
+
+为了证明论文主张成立，至少需要：
+
+```text
+Baseline 0: repeat last observed frame / zero velocity
+Baseline 1: independent predictor，A/B 分别预测再拼接
+Baseline 2: concat predictor，拼接双人历史但无显式 relation module
+Ours: relation-aware joint predictor
+```
+
+如果 `Ours` 不能明显优于 `independent` 和 `concat`，尤其是在长期误差和交互关系指标上，论文主张不成立。
+
+## 指标
+
+主指标：
+
+```text
+future MSE
+rotation MSE
+translation MSE
+long-horizon MSE
+```
+
+交互指标：
+
+```text
+relative root distance error
+relative orientation error
+inter-person distance consistency
+```
+
+如果能稳定恢复 joint xyz，再加入：
+
+```text
+MPJPE
+inter-person joint distance error
+```
+
+后续做多模态预测时再加入：
+
+```text
+best-of-K error
+diversity
+coverage
+```
+
+## 非目标
+
+第一阶段不要把以下内容作为论文主目标：
+
+```text
+ReGenNet Table 4 完整复现
+自然语言条件预测
+动作标签条件预测
+actor-only -> reactor-only 反应生成
+SMPL-X 转换
+ST-GCN recognition evaluator
+```
+
+这些可以作为后续扩展或相关 baseline，但不能继续阻塞 forecasting 主线。
+
+## 工程关系
+
+当前 ReGenNet InterHuman 50K baseline 仍有价值，但定位应调整为：
+
+```text
+历史 backbone / 生成式 baseline / 工程资产
+```
+
+它不是最终论文任务，因为当前 `cmdm` 训练仍是把双人动作拆成 actor 条件 `cmotion` 与 reactor 目标 `motion`，不等价于：
+
+```text
+前 20% 双人动作 -> 后 80% 双人动作
+```
+
+因此需要新增 forecasting 数据组织、训练入口和评估脚本。
+
+## 可投稿贡献表述
+
+推荐贡献组织：
+
+```text
+1. 定义一个基于部分双人观测的交互动作联合未来预测协议。
+2. 提出显式关系推理模块，从可观测运动中学习双人动态关系。
+3. 证明关系建模优于独立预测和无关系拼接，尤其改善长期预测与交互一致性。
+```
+
+## 外部文献信号
+
+近期相关工作支持本方向：
+
+- ReGenNet 关注 human action-reaction synthesis，但其主任务不是双人联合未来预测：https://arxiv.org/abs/2403.11882
+- Joint Relation Transformer 明确指出双人姿态预测需要建模 body-body interaction：https://arxiv.org/abs/2304.05758
+- InterGen / multi-human motion generation 系列强调多人体生成中的交互关系和空间约束：https://arxiv.org/abs/2404.05218
+
+## 当前待用户确认
+
+需要用户确认的最终决策：
+
+```text
+论文第一阶段是否正式锁定为：
+InterHuman 150-frame window, 30-frame observation, 120-frame joint two-person forecasting,
+核心创新为 relation-aware joint predictor。
+```
+
+确认后再把该目标写入 `AGENTS.md` 的长期记忆，并进入 forecasting loader / baseline / evaluator 的设计与实现。

--- a/docs/ai/context/20260603-160713-forecasting-final-goal-design.md
+++ b/docs/ai/context/20260603-160713-forecasting-final-goal-design.md
@@ -1,0 +1,629 @@
+# 交互感知双人动作联合预测设计文档
+
+## 目标已锁定
+
+论文第一阶段正式锁定为：
+
+```text
+Interaction-aware joint forecasting of two-person human motion from partial observations.
+```
+
+中文：
+
+```text
+基于部分观测的交互感知双人动作联合未来预测。
+```
+
+主协议：
+
+```text
+dataset: InterHuman
+window_len: 150
+obs_len: 30
+pred_len: 120
+input:  前 30 帧双人动作
+target: 后 120 帧双人动作
+task:   联合预测两个人未来动作
+```
+
+## 当前进程状态
+
+已停止当前 ReGenNet 50K baseline 长跑进程。
+
+停止前状态：
+
+```text
+save_dir: save/interhuman/paper_config_l8_d512_accum64_50000_baseline
+last checkpoint: model000020000.pt / opt000020000.pt
+log last status: Interrupted system call
+```
+
+当前未发现 ReGenNet 训练进程残留，`nvidia-smi --query-compute-apps` 返回为空。
+
+## 当前工程现状
+
+### 可复用资产
+
+数据：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+```
+
+InterHuman H5 格式：
+
+```text
+shape: [T, 25, 12]
+body_model: smpl
+rotation: rot6d
+translation_slot: 24
+actor_rot6d: [:, :24, 0:6]
+actor_translation: [:, 24, 0:3]
+reactor_rot6d: [:, :24, 6:12]
+reactor_translation: [:, 24, 6:9]
+translation_origin: actor frame 0
+```
+
+本地可用窗口数量：
+
+```text
+InterHuman train: 6021 条，长度 >=150 的有 2910 条。
+InterHuman val:   580 条，长度 >=150 的有 226 条。
+InterHuman test:  1175 条，长度 >=150 的有 508 条。
+```
+
+环境：
+
+```text
+torch: 1.7.1
+GPU: NVIDIA GeForce RTX 3080
+CUDA available: true
+```
+
+已有代码可复用：
+
+```text
+preprocess/interhuman_as.py      # InterHuman H5 生成逻辑
+data_loaders/a2m/interhuman.py   # H5 读取经验
+utils/rotation_conversions.py    # rot6d / matrix / axis-angle 转换
+model/rotation2xyz.py            # 后续 MPJPE / xyz 指标可用
+train/training_loop.py           # checkpoint / log / grad accumulation 经验可参考
+```
+
+### 不能直接复用的部分
+
+当前 ReGenNet 主训练路径：
+
+```text
+train/train_mdm.py
+utils/model_util.py
+model/cmdm.py
+diffusion/gaussian_diffusion.py
+data_loaders/tensors.py::ccollate
+```
+
+不适合直接作为 forecasting 主线，原因：
+
+```text
+ccollate 会把 [T,25,12] 按 channel 拆成 actor 条件 cmotion 和 reactor 目标 motion。
+CMDM.forward() 硬依赖 y["cmotion"]。
+diffusion training loss 只对 reactor 目标加噪，关系 loss 也是 cmotion 与 reactor 的相对关系。
+eval/eval_cmdm.py 只支持 NTU / Chi3D 的 ST-GCN 评估，不支持 InterHuman forecasting MSE 指标。
+```
+
+因此不能靠改命令实现：
+
+```text
+前 30 帧双人动作 -> 后 120 帧双人动作
+```
+
+需要新增 forecasting 专用数据、模型、训练和评估路径。
+
+## 第一阶段设计原则
+
+1. 先做确定性 forecasting，不先做 diffusion。
+2. 先证明 relation-aware joint predictor 明显优于 independent / concat。
+3. 先用 MSE 类和交互关系指标闭环，不依赖 ST-GCN recognition checkpoint。
+4. 保留 ReGenNet 作为历史 backbone / 后续生成式 baseline，不让它阻塞主线。
+5. 第一版只用 InterHuman；NTU120-AS 和 Chi3D 后续作为扩展。
+
+## 数据设计
+
+新增数据模块建议：
+
+```text
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+```
+
+输出格式建议从 H5 的 `[T,25,12]` 转成 active vector，避免 zero padding channel 污染 MSE：
+
+```text
+person_active_dim = 24 * 6 + 3 = 147
+two_person_dim = 294
+obs:    [obs_len, 2, 147]
+target: [pred_len, 2, 147]
+```
+
+active vector 映射：
+
+```text
+person A = actor rot6d [:24,0:6] + actor translation [24,0:3]
+person B = reactor rot6d [:24,6:12] + reactor translation [24,6:9]
+```
+
+训练采样：
+
+```text
+只保留 T >= 150 的样本。
+每次 __getitem__ 随机裁剪连续 150 帧。
+前 30 帧为 obs，后 120 帧为 target。
+```
+
+验证/测试采样：
+
+```text
+第一版使用 center crop，保证确定性。
+后续可扩展为 multi-window evaluation。
+```
+
+归一化：
+
+```text
+使用 train split 统计 active vector 的 mean/std。
+训练 loss 在 normalized space 计算。
+评估指标在 original scale 计算。
+```
+
+注意：
+
+```text
+不要对长度 <150 的序列 padding 后纳入第一阶段主协议。
+padding 会伪造未来，破坏 forecasting 任务。
+```
+
+## 模型设计
+
+新增模型模块建议：
+
+```text
+model/forecasting.py
+```
+
+### Baseline 0：Repeat / Zero Velocity
+
+无需训练：
+
+```text
+pred[t] = obs[-1]
+```
+
+用途：
+
+```text
+建立最低可用误差下界。
+验证 evaluator 和指标没有实现错误。
+```
+
+### Baseline 1：Independent Predictor
+
+定义：
+
+```text
+A_obs -> A_future
+B_obs -> B_future
+concat(A_future, B_future)
+```
+
+模型：
+
+```text
+共享或独立 GRU/Transformer encoder
+每个人只看自己的 obs
+decoder 直接输出 pred_len * 147
+```
+
+约束：
+
+```text
+不能读取另一个人的 obs。
+```
+
+### Baseline 2：Concat No-Relation Predictor
+
+定义：
+
+```text
+concat(A_obs, B_obs) -> future(A,B)
+```
+
+模型：
+
+```text
+GRU/Transformer encoder 读取 [obs_len, 294]
+MLP decoder 输出 [pred_len, 2, 147]
+```
+
+约束：
+
+```text
+允许看到两个人历史，但不显式构造 relation features / relation encoder。
+```
+
+### Ours：Relation-Aware Joint Predictor
+
+输入：
+
+```text
+obs: [B, obs_len, 2, 147]
+```
+
+关系特征：
+
+```text
+relative root translation: trans_A - trans_B
+relative root velocity: velocity_A - velocity_B
+root distance: ||trans_A - trans_B||
+relative root orientation: R_A^T R_B
+```
+
+第一版结构：
+
+```text
+person_encoder(A_obs) -> h_A
+person_encoder(B_obs) -> h_B
+relation_encoder(relation_features) -> h_rel
+fuse(h_A, h_B, h_rel) -> decoder -> future(A,B)
+```
+
+推荐先用小型 GRU/MLP：
+
+```text
+hidden_dim: 256 或 512
+num_layers: 2
+decoder: MLP direct prediction
+```
+
+理由：
+
+```text
+PyTorch 版本是 1.7.1，先避免依赖较新的 Transformer API。
+任务第一阶段更需要清晰 ablation，而不是复杂生成模型。
+```
+
+## Loss 设计
+
+主训练 loss：
+
+```text
+normalized active-vector MSE
+```
+
+可选关系 loss：
+
+```text
+relative root distance MSE
+relative orientation MSE
+translation MSE
+```
+
+第一版建议：
+
+```text
+先只训练 reconstruction MSE。
+relation loss 作为 ablation 加入。
+```
+
+原因：
+
+```text
+如果 relation-aware architecture 在相同 reconstruction loss 下已优于 baseline，主张更干净。
+否则再判断是否需要 relation loss 强化交互一致性。
+```
+
+## 评估设计
+
+新增评估模块建议：
+
+```text
+eval/eval_forecasting.py
+utils/forecasting_metrics.py
+```
+
+必须指标：
+
+```text
+future_mse
+rotation_mse
+translation_mse
+short_mse       # pred frames 0-39
+mid_mse         # pred frames 40-79
+long_mse        # pred frames 80-119
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+指标计算原则：
+
+```text
+rotation_mse 只计算 24 个 rot6d joints。
+translation_mse 只计算 active translation，不计算 padding zero channel。
+relative_root_distance_error 使用 actor/reactor translation。
+relative_orientation_error 使用 root rot6d -> matrix 后计算相对旋转角。
+```
+
+后续指标：
+
+```text
+MPJPE
+inter-person joint distance error
+collision / penetration proxy
+best-of-K error
+diversity
+coverage
+```
+
+## 训练入口设计
+
+新增入口建议：
+
+```text
+train/train_forecasting.py
+```
+
+核心参数：
+
+```text
+--dataset interhuman
+--data_path dataset/interhuman/smpl/conditioned
+--save_dir save/forecasting/interhuman/...
+--window_len 150
+--obs_len 30
+--pred_len 120
+--model_type repeat|independent|concat|relation
+--batch_size
+--num_steps
+--lr
+--hidden_dim
+--num_layers
+--seed
+--max_samples
+```
+
+保存内容：
+
+```text
+args.json
+normalizer.pt 或 normalizer.json
+model*.pt
+metrics_val.yaml
+metrics_test.yaml
+```
+
+训练循环不建议直接复用 `TrainLoop`，原因：
+
+```text
+现有 TrainLoop 绑定 diffusion.training_losses 和 DDP 逻辑。
+forecasting 第一版只需要标准 supervised loss。
+```
+
+可以复用经验：
+
+```text
+checkpoint 命名
+grad_accum_steps
+log_interval / save_interval
+max_samples smoke
+num_workers=0 的 InterHuman 退出策略
+```
+
+## 任务分解
+
+### P0：协议冻结与文档
+
+产出：
+
+```text
+AGENTS.md 正式记录目标。
+docs/ai/context 设计文档。
+```
+
+状态：
+
+```text
+已完成。
+```
+
+### P1：Forecasting Dataset 与 Normalizer
+
+任务：
+
+```text
+新增 InterHumanForecastDataset。
+实现 active vector extract / restore。
+实现 random train crop 和 deterministic eval crop。
+实现 train mean/std 统计和缓存。
+```
+
+验收：
+
+```text
+train/val/test loader 可返回 obs/target。
+shape = obs [B,30,2,147], target [B,120,2,147]。
+无 NaN / Inf。
+长度 <150 样本不会进入第一阶段数据集。
+```
+
+### P2：Forecasting Metrics 与 Repeat Baseline
+
+任务：
+
+```text
+实现 metrics。
+实现 repeat baseline evaluator。
+输出 YAML/JSON 指标。
+```
+
+验收：
+
+```text
+pred == target 时所有 MSE 类指标为 0。
+repeat baseline 能在 test split 上完整跑完。
+```
+
+### P3：Independent 与 Concat Baseline
+
+任务：
+
+```text
+实现 supervised train loop。
+实现 independent predictor。
+实现 concat no-relation predictor。
+训练 smoke 和中等训练。
+```
+
+验收：
+
+```text
+max_samples smoke 2-5 step 通过。
+完整 train 可保存 checkpoint。
+val/test 指标可复现。
+```
+
+### P4：Relation-Aware Joint Predictor
+
+任务：
+
+```text
+实现 relation feature extraction。
+实现 relation encoder。
+实现 relation-aware predictor。
+与 independent / concat 使用相同数据协议和训练设置。
+```
+
+验收：
+
+```text
+relation-aware 在 long_mse 和交互指标上优于 independent / concat。
+如果没有优势，回到模型假设检查，而不是继续堆功能。
+```
+
+### P5：Ablation 与论文表格
+
+任务：
+
+```text
+去掉 relation encoder。
+只用 relative translation。
+只用 relative orientation。
+不同观测比例：10% / 20% / 30% / 50%。
+不同窗口协议可作为补充：60/150。
+```
+
+验收：
+
+```text
+形成主结果表、ablation 表、长期误差曲线。
+```
+
+### P6：可视化与定性分析
+
+任务：
+
+```text
+把 active vector 还原为 H5-like motion。
+复用 render / rot2xyz 或新增轻量可视化。
+保存若干 obs/gt/pred 对比样本。
+```
+
+验收：
+
+```text
+至少 8 个 test 样本可视化。
+动作数值有限，轨迹和相对距离曲线可检查。
+```
+
+### P7：扩展路线
+
+不进入第一阶段阻塞项：
+
+```text
+NTU120-AS action-conditioned forecasting
+Chi3D 小规模泛化验证
+InterHuman 文本条件预测
+diffusion / ReGenNet forecasting baseline
+SMPL-X 统一表示
+```
+
+## 最短可执行路径
+
+最短闭环顺序：
+
+```text
+1. P1 dataset
+2. P2 repeat baseline evaluator
+3. P3 concat baseline
+4. P3 independent baseline
+5. P4 relation-aware model
+6. P5 ablation table
+```
+
+不要先做：
+
+```text
+复杂 graph network
+diffusion forecasting
+natural language condition
+Table 4 evaluator
+SMPL-X conversion
+```
+
+## 风险与判断标准
+
+### 风险 1：150 帧过滤后训练样本减少
+
+当前 train 仍有 2910 条，第一阶段可接受。
+
+如果训练不稳：
+
+```text
+增加每条长序列的随机窗口采样次数。
+或补充 120 帧窗口协议作为消融。
+```
+
+### 风险 2：translation 和 rotation 尺度不一致
+
+必须使用 normalizer，并在原始尺度报告指标。
+
+### 风险 3：relation-aware 没有明显优势
+
+这不是实现小问题，而是论文主张风险。处理顺序：
+
+```text
+先检查 independent / concat 是否公平。
+再检查 relation features 是否从 obs 中正确提取。
+再增加 relation loss 或 cross-attention。
+最后才考虑更复杂图网络。
+```
+
+### 风险 4：长期预测 MSE 偏向平均动作
+
+第一阶段先承认 deterministic forecasting 只验证关系建模。
+多模态预测、best-of-K 和 diversity 后续再做。
+
+## 下一步立即任务
+
+下一轮实现应从 P1 开始：
+
+```text
+新增 data_loaders/forecasting/interhuman.py
+新增 data_loaders/forecasting/tensors.py
+新增 utils/forecasting_motion.py
+新增最小 shape/finite smoke
+```
+
+完成 P1/P2 后再进入模型实现。

--- a/docs/ai/context/20260603-161246-academic-research-skills-install.md
+++ b/docs/ai/context/20260603-161246-academic-research-skills-install.md
@@ -1,0 +1,25 @@
+# academic-research-skills 本地安装记录
+
+## 背景
+
+- 用户要求将 `https://github.com/Imbad0202/academic-research-skills.git` 安装为本地 skill。
+- 该仓库默认分支为 `main`，HEAD 为 `83161923589b0a5f2aa77fef620d97fdcb0247a1`。
+- 仓库不是单一 skill，而是包含 4 个带 `SKILL.md` 的 skill 目录。
+
+## 安装内容
+
+已通过 Codex `skill-installer` 安装到 `/home/rpartx3080/.codex/skills/`：
+
+- `academic-pipeline`
+- `deep-research`
+- `academic-paper`
+- `academic-paper-reviewer`
+
+## 取舍
+
+- 因用户提供的是完整 GitHub 仓库链接，且仓库内 4 个目录都符合 skill 结构，所以按 skill 集合一次性安装。
+- 没有覆盖历史 `docs/ai/context/` 文件；本记录为新增上下文。
+
+## 后续
+
+- 需要重启 Codex 才能让新安装的 skills 出现在后续会话的可用 skill 列表中。

--- a/docs/ai/context/20260603-161334-forecasting-p1-p2-design.md
+++ b/docs/ai/context/20260603-161334-forecasting-p1-p2-design.md
@@ -1,0 +1,492 @@
+# Forecasting P1/P2 详细设计
+
+## 目标
+
+本设计只覆盖第一阶段的最小闭环：
+
+```text
+P1: InterHuman forecasting dataset + active vector + normalizer
+P2: forecasting metrics + repeat / zero-velocity baseline evaluator
+```
+
+不修改当前代码实现，不启动训练。
+
+## 为什么先做 P1/P2
+
+论文主张是：
+
+```text
+显式建模双人交互关系可以改善双人未来动作联合预测。
+```
+
+但在 relation-aware model 前必须先确认：
+
+```text
+1. 数据协议明确。
+2. 输入输出 shape 正确。
+3. 指标能反映 future motion 和 inter-person relation。
+4. repeat baseline 能作为 sanity check。
+```
+
+如果没有 P1/P2，后续模型结果无法判断是模型有效，还是数据切分、padding、指标或尺度处理错误。
+
+## 固定协议
+
+第一阶段协议：
+
+```text
+dataset: InterHuman
+source: dataset/interhuman/smpl/conditioned/interhuman_{train,val,test}.h5
+window_len: 150
+obs_len: 30
+pred_len: 120
+input: 前 30 帧双人动作
+target: 后 120 帧双人动作
+```
+
+长度规则：
+
+```text
+T >= 150: 可用
+T < 150: 过滤
+```
+
+不能 padding，原因：
+
+```text
+padding 会把不存在的未来动作变成重复帧，污染 forecasting 指标。
+```
+
+## H5 到 active vector
+
+InterHuman H5 原始格式：
+
+```text
+motion: [T, 25, 12]
+```
+
+slot 含义：
+
+```text
+actor_rot6d:        motion[:, :24, 0:6]
+actor_translation:  motion[:, 24, 0:3]
+reactor_rot6d:      motion[:, :24, 6:12]
+reactor_translation:motion[:, 24, 6:9]
+```
+
+active vector 格式：
+
+```text
+person_dim = 24 * 6 + 3 = 147
+two_person_dim = 2 * 147 = 294
+```
+
+单人向量：
+
+```text
+person = concat(rot6d.reshape(24 * 6), translation)
+```
+
+双人样本：
+
+```text
+motion_active: [T, 2, 147]
+motion_active[:, 0] = actor
+motion_active[:, 1] = reactor
+```
+
+设计理由：
+
+```text
+H5 的 [25,12] 包含为两个人共用 layout 而留下的 zero channel。
+直接对 [25,12] 做 MSE 会把无效 zero channel 纳入指标。
+active vector 只保留真实监督维度。
+```
+
+## Dataset 输出
+
+建议 dataset item：
+
+```text
+{
+  "obs": Tensor[30, 2, 147],
+  "target": Tensor[120, 2, 147],
+  "sample_id": str,
+  "start": int,
+  "length": int,
+}
+```
+
+训练模式：
+
+```text
+对每条 T >= 150 的序列随机选择 start。
+window = motion[start:start+150]
+obs = window[:30]
+target = window[30:]
+```
+
+验证/测试模式：
+
+```text
+start = floor((T - 150) / 2)
+使用 center crop，保证确定性。
+```
+
+后续可扩展：
+
+```text
+multi-window eval
+固定 stride eval
+不同 window_len / obs_ratio 协议
+```
+
+但第一版不做，避免评估口径过早复杂化。
+
+## Collate 设计
+
+由于 P1 固定窗口，batch 内不需要 padding。
+
+建议 batch：
+
+```text
+obs:    Tensor[B, 30, 2, 147]
+target: Tensor[B, 120, 2, 147]
+meta:   list[dict]
+```
+
+不要复用 `data_loaders/tensors.py::ccollate`，原因：
+
+```text
+ccollate 的语义是 actor condition / reactor target。
+forecasting 的语义是 observed prefix / future suffix。
+```
+
+## Normalizer 设计
+
+训练时需要归一化，否则 rotation 和 translation 的尺度差异会影响 loss。
+
+统计来源：
+
+```text
+只使用 train split。
+只统计 T >= 150 的样本。
+统计 active vector 全部时间帧。
+```
+
+建议统计维度：
+
+```text
+mean: [1, 1, 2, 147]
+std:  [1, 1, 2, 147]
+```
+
+使用方式：
+
+```text
+normalized = (value - mean) / std
+original = normalized * std + mean
+```
+
+std 防护：
+
+```text
+std < eps 的维度设为 1.0
+eps = 1e-6
+```
+
+保存格式建议：
+
+```text
+save/forecasting/.../normalizer.pt
+```
+
+也可同时保存摘要：
+
+```text
+normalizer.json
+```
+
+摘要包含：
+
+```text
+dataset
+data_path
+window_len
+obs_len
+pred_len
+num_train_sequences_used
+person_dim
+eps
+```
+
+## Metrics 输入输出
+
+评估函数输入：
+
+```text
+pred:   Tensor[B, 120, 2, 147]
+target: Tensor[B, 120, 2, 147]
+obs:    Tensor[B, 30, 2, 147]  # 部分交互指标需要 obs[-1]
+```
+
+要求：
+
+```text
+指标在 original scale 上计算。
+不要在 normalized space 报告论文指标。
+```
+
+输出：
+
+```text
+{
+  "future_mse": float,
+  "rotation_mse": float,
+  "translation_mse": float,
+  "short_mse": float,
+  "mid_mse": float,
+  "long_mse": float,
+  "relative_root_distance_error": float,
+  "relative_orientation_error": float,
+  "inter_person_distance_consistency": float,
+}
+```
+
+## 指标定义
+
+### future_mse
+
+```text
+mean((pred - target)^2)
+```
+
+作用：
+
+```text
+整体重建误差。
+```
+
+### rotation_mse
+
+只取每人的前 144 维：
+
+```text
+rot = person[:, :144]
+```
+
+定义：
+
+```text
+mean((pred_rot - target_rot)^2)
+```
+
+### translation_mse
+
+只取每人的最后 3 维：
+
+```text
+trans = person[:, 144:147]
+```
+
+定义：
+
+```text
+mean((pred_trans - target_trans)^2)
+```
+
+### short / mid / long mse
+
+对 pred_len=120 做三段：
+
+```text
+short: frames 0..39
+mid:   frames 40..79
+long:  frames 80..119
+```
+
+作用：
+
+```text
+验证 relation-aware model 是否真正改善长期预测。
+```
+
+### relative_root_distance_error
+
+取两人的 root translation：
+
+```text
+trans_A = person_A[..., 144:147]
+trans_B = person_B[..., 144:147]
+dist = norm(trans_A - trans_B)
+```
+
+定义：
+
+```text
+mean(abs(pred_dist - target_dist))
+```
+
+### relative_orientation_error
+
+取两人的 root rot6d：
+
+```text
+root_A = person_A[..., 0:6]
+root_B = person_B[..., 0:6]
+```
+
+转换为 rotation matrix：
+
+```text
+R_A = rot6d_to_matrix(root_A)
+R_B = rot6d_to_matrix(root_B)
+R_rel = R_A^T R_B
+```
+
+误差：
+
+```text
+angle(R_rel_pred^T R_rel_target)
+```
+
+报告单位建议：
+
+```text
+radian
+```
+
+后续论文表格可额外换算为 degree。
+
+### inter_person_distance_consistency
+
+第一版定义为相对 root distance 的时间变化误差：
+
+```text
+delta_dist[t] = dist[t] - dist[t-1]
+mean(abs(pred_delta_dist - target_delta_dist))
+```
+
+作用：
+
+```text
+惩罚两人关系变化趋势错误，而不只看绝对距离。
+```
+
+## Repeat / Zero-Velocity Baseline
+
+定义：
+
+```text
+pred[:, t] = obs[:, -1]
+```
+
+shape：
+
+```text
+obs[-1]: [B, 2, 147]
+pred:    [B, 120, 2, 147]
+```
+
+用途：
+
+```text
+1. 验证 evaluator 能跑完整 test split。
+2. 提供最低 baseline。
+3. 捕获数据切分错误：如果 repeat baseline 异常好，可能发生 target 泄漏或窗口切错。
+```
+
+## Sanity Checks
+
+P1 必须通过：
+
+```text
+dataset train/val/test 长度等于 T>=150 的样本数。
+obs shape = [30,2,147]。
+target shape = [120,2,147]。
+所有 obs/target 数值有限。
+train 模式同一样本多次读取 start 可变化。
+eval 模式同一样本多次读取 start 固定。
+```
+
+P2 必须通过：
+
+```text
+pred == target 时所有 MSE 类指标为 0。
+relative_root_distance_error 为 0。
+relative_orientation_error 接近 0。
+repeat baseline 可完整评估 test split。
+metrics 可保存为 yaml/json。
+```
+
+## 文件设计
+
+后续实现建议新增：
+
+```text
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+utils/forecasting_motion.py
+utils/forecasting_metrics.py
+eval/eval_forecasting.py
+```
+
+职责划分：
+
+```text
+interhuman.py: H5 读取、长度过滤、窗口裁剪。
+tensors.py: forecasting collate。
+forecasting_motion.py: active vector extract/restore、normalizer。
+forecasting_metrics.py: 指标计算。
+eval_forecasting.py: repeat baseline 与模型评估入口。
+```
+
+本轮只写设计，不创建这些代码文件。
+
+## 验收命令草案
+
+后续实现后应支持类似命令：
+
+```text
+python -m eval.eval_forecasting \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --baseline repeat \
+  --window_len 150 \
+  --obs_len 30 \
+  --pred_len 120 \
+  --batch_size 64 \
+  --split test
+```
+
+预期输出：
+
+```text
+save/forecasting/interhuman/repeat_test_metrics.yaml
+```
+
+## 当前不做
+
+```text
+不改 train/train_mdm.py。
+不改 model/cmdm.py。
+不改 diffusion/gaussian_diffusion.py。
+不接入 ReGenNet diffusion。
+不做 relation-aware model。
+不做自然语言或动作标签条件。
+不做 SMPL-X 转换。
+```
+
+## 下一步
+
+确认本设计后，再进入 P1 实现：
+
+```text
+1. active vector extract/restore。
+2. InterHumanForecastDataset。
+3. forecasting collate。
+4. normalizer 统计。
+5. shape/finite smoke。
+```
+
+P1 完成并验证后，再进入 P2 repeat baseline evaluator。

--- a/docs/ai/context/20260603-161803-forecasting-p1-p6-roadmap.md
+++ b/docs/ai/context/20260603-161803-forecasting-p1-p6-roadmap.md
@@ -1,0 +1,893 @@
+# Forecasting P1-P6 完整路线图
+
+## 文档定位
+
+这是论文第一阶段实现的原始路线图。后续即使按 P1、P2 逐步实现，也必须能回溯到这里，避免局部实现完成后偏离最终目标。
+
+后续每个阶段完成时，应新建阶段记录文档，并引用本文件：
+
+```text
+docs/ai/context/20260603-161803-forecasting-p1-p6-roadmap.md
+```
+
+不得用新的局部计划覆盖本路线图。
+
+## 最终目标
+
+论文第一阶段正式目标：
+
+```text
+Interaction-aware joint forecasting of two-person human motion from partial observations.
+```
+
+中文：
+
+```text
+基于部分观测的交互感知双人动作联合未来预测。
+```
+
+固定主协议：
+
+```text
+dataset: InterHuman
+window_len: 150
+obs_len: 30
+pred_len: 120
+input:  前 30 帧双人动作
+target: 后 120 帧双人动作
+output: 两个人未来动作联合预测
+```
+
+核心论文假设：
+
+```text
+双人未来动作预测不是两个单人未来预测的简单拼接；
+显式建模两人关系应改善长期预测和交互一致性。
+```
+
+如果 relation-aware model 不能优于 independent / concat baseline，尤其不能改善 long-horizon 和交互关系指标，则论文主张不成立，不能继续包装成成功结果。
+
+## 全局边界
+
+第一阶段只做：
+
+```text
+InterHuman 150-frame deterministic two-person forecasting
+active vector 表示
+MSE 类和交互关系指标
+repeat / independent / concat / relation-aware 四类模型或 baseline
+```
+
+第一阶段不做：
+
+```text
+ReGenNet Table 4 完整复现
+自然语言条件预测
+动作标签条件预测
+SMPL-X 转换
+ST-GCN recognition evaluator
+diffusion forecasting
+多模态 best-of-K / diversity
+```
+
+这些内容可以作为后续扩展，但不能阻塞 P1-P6。
+
+## 阶段依赖图
+
+```text
+P1 Dataset + Normalizer
+  -> P2 Metrics + Repeat Baseline
+    -> P3 Independent / Concat Baselines
+      -> P4 Relation-Aware Predictor
+        -> P5 Ablation + Paper Tables
+          -> P6 Visualization + Qualitative Analysis
+```
+
+禁止跳过：
+
+```text
+P1/P2 未完成，不实现 P3。
+P3 未完成，不实现 P4。
+P4 未完成，不写 P5 主结果结论。
+P5 未完成，不把 P6 可视化当作主证明。
+```
+
+## 统一数据表示
+
+InterHuman H5：
+
+```text
+motion: [T, 25, 12]
+actor_rot6d:         motion[:, :24, 0:6]
+actor_translation:   motion[:, 24, 0:3]
+reactor_rot6d:       motion[:, :24, 6:12]
+reactor_translation: motion[:, 24, 6:9]
+```
+
+Forecasting active vector：
+
+```text
+person_dim = 24 * 6 + 3 = 147
+two_person_dim = 294
+motion_active: [T, 2, 147]
+```
+
+窗口：
+
+```text
+obs:    [30, 2, 147]
+target: [120, 2, 147]
+```
+
+长度规则：
+
+```text
+T >= 150: 使用
+T < 150: 过滤
+```
+
+不得 padding，原因是 padding 会伪造未来动作。
+
+## 统一指标
+
+所有模型和 baseline 必须报告同一组指标：
+
+```text
+future_mse
+rotation_mse
+translation_mse
+short_mse
+mid_mse
+long_mse
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+指标必须在 original scale 上计算。训练可以使用 normalized space，但论文指标不能用 normalized 值。
+
+## P1：Forecasting Dataset + Normalizer
+
+### 目标
+
+建立 InterHuman forecasting 数据协议，让所有后续模型读取完全一致的 `obs / target`。
+
+### 输入
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+```
+
+### 设计任务
+
+新增 forecasting 数据读取逻辑：
+
+```text
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+utils/forecasting_motion.py
+```
+
+需要实现：
+
+```text
+1. H5 -> active vector [T,2,147]
+2. active vector -> H5-like motion，供后续可视化使用
+3. T >= 150 过滤
+4. train random crop
+5. val/test center crop
+6. forecasting collate
+7. train split normalizer
+8. normalizer 保存和加载
+```
+
+### 输出
+
+Dataset item：
+
+```text
+{
+  "obs": Tensor[30, 2, 147],
+  "target": Tensor[120, 2, 147],
+  "sample_id": str,
+  "start": int,
+  "length": int,
+}
+```
+
+Batch：
+
+```text
+obs:    Tensor[B, 30, 2, 147]
+target: Tensor[B, 120, 2, 147]
+meta:   list[dict]
+```
+
+Normalizer：
+
+```text
+mean: [1,1,2,147]
+std:  [1,1,2,147]
+```
+
+### 验收标准
+
+P1 通过条件：
+
+```text
+train dataset length = 2910
+val dataset length = 226
+test dataset length = 508
+obs shape = [30,2,147]
+target shape = [120,2,147]
+所有 obs/target 数值有限
+train 同一样本多次读取 start 可变化
+val/test 同一样本多次读取 start 固定
+normalizer 可保存和加载
+normalize -> denormalize 最大误差在浮点容忍范围内
+```
+
+### 失败回退
+
+如果 shape 或样本数不对：
+
+```text
+先检查 T>=150 过滤。
+再检查 split 是否读取了正确 H5。
+最后检查 active vector 映射。
+```
+
+如果 normalized 数值异常：
+
+```text
+检查 std 防护。
+检查是否把 padding zero channel 纳入统计。
+```
+
+### 阶段记录
+
+P1 完成后必须新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p1-dataset-result.md
+```
+
+记录：
+
+```text
+实现文件
+shape 检查
+样本数
+normalizer 统计摘要
+smoke 命令
+是否偏离本路线图
+```
+
+## P2：Metrics + Repeat Baseline
+
+### 目标
+
+在训练模型前，让评估闭环先成立。
+
+### 设计任务
+
+新增：
+
+```text
+utils/forecasting_metrics.py
+eval/eval_forecasting.py
+```
+
+实现：
+
+```text
+1. future_mse
+2. rotation_mse
+3. translation_mse
+4. short/mid/long_mse
+5. relative_root_distance_error
+6. relative_orientation_error
+7. inter_person_distance_consistency
+8. repeat baseline
+9. metrics yaml/json 保存
+```
+
+### Repeat baseline
+
+定义：
+
+```text
+pred[:, t] = obs[:, -1]
+```
+
+它不是论文贡献，只是 sanity baseline。
+
+### 验收标准
+
+P2 通过条件：
+
+```text
+pred == target 时 MSE 类指标为 0
+pred == target 时 relative_root_distance_error 为 0
+pred == target 时 relative_orientation_error 接近 0
+repeat baseline 可完整评估 test split
+repeat baseline 输出 metrics 文件
+所有指标 key 固定，不随模型变化
+```
+
+### 失败回退
+
+如果 `pred == target` 指标非 0：
+
+```text
+先修 metrics，不进入 P3。
+```
+
+如果 repeat baseline 评估无法跑完：
+
+```text
+先修 dataset / collate / dataloader，不进入模型训练。
+```
+
+### 阶段记录
+
+P2 完成后必须新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p2-metrics-repeat-result.md
+```
+
+记录：
+
+```text
+sanity check 结果
+repeat baseline test 指标
+metrics 文件路径
+是否偏离本路线图
+```
+
+## P3：Independent / Concat Baselines
+
+### 目标
+
+建立两个可训练 baseline，用于证明 relation-aware model 不是只赢 repeat baseline。
+
+### Baseline 1：Independent Predictor
+
+定义：
+
+```text
+A_obs -> A_future
+B_obs -> B_future
+concat(A_future, B_future)
+```
+
+约束：
+
+```text
+A 分支不能看到 B_obs。
+B 分支不能看到 A_obs。
+```
+
+建议结构：
+
+```text
+shared GRU encoder 或 two-tower GRU
+MLP decoder
+输出 [B,120,2,147]
+```
+
+### Baseline 2：Concat No-Relation Predictor
+
+定义：
+
+```text
+concat(A_obs, B_obs) -> future(A,B)
+```
+
+约束：
+
+```text
+可以看到双人历史，但不能显式构造 relation features。
+```
+
+建议结构：
+
+```text
+GRU encoder over [B,30,294]
+MLP decoder -> [B,120,2,147]
+```
+
+### 设计任务
+
+新增：
+
+```text
+model/forecasting.py
+train/train_forecasting.py
+```
+
+实现：
+
+```text
+1. supervised training loop
+2. checkpoint 保存
+3. args.json 保存
+4. normalizer 加载
+5. val/test evaluation
+6. grad_accum_steps
+7. max_samples smoke
+```
+
+### 训练 loss
+
+第一版使用：
+
+```text
+normalized active-vector MSE
+```
+
+不要在 P3 加 relation loss。
+
+### 验收标准
+
+P3 通过条件：
+
+```text
+independent max_samples smoke 通过
+concat max_samples smoke 通过
+两个模型都能保存 checkpoint
+两个模型都能在 val/test 输出统一 metrics
+两个模型至少优于 repeat baseline 的 future_mse
+concat 与 independent 的差异可解释
+```
+
+### 失败回退
+
+如果训练 loss 不下降：
+
+```text
+检查 normalizer。
+检查 target 是否错位。
+检查 decoder 输出 shape。
+```
+
+如果模型赢不了 repeat：
+
+```text
+先降低模型复杂度或学习率排查。
+不要直接进入 P4。
+```
+
+### 阶段记录
+
+P3 完成后必须新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p3-baselines-result.md
+```
+
+记录：
+
+```text
+模型配置
+训练命令
+checkpoint
+val/test metrics
+repeat / independent / concat 对比表
+是否偏离本路线图
+```
+
+## P4：Relation-Aware Joint Predictor
+
+### 目标
+
+实现论文核心模型：显式关系推理 + 双人联合未来预测。
+
+### 输入
+
+```text
+obs: [B,30,2,147]
+```
+
+### 关系特征
+
+第一版关系特征：
+
+```text
+relative root translation: trans_A - trans_B
+relative root velocity: velocity_A - velocity_B
+root distance: ||trans_A - trans_B||
+relative root orientation: R_A^T R_B
+```
+
+可以派生：
+
+```text
+distance velocity
+approach / separate trend
+```
+
+但第一版不要加入人工阶段标签。
+
+### 模型结构
+
+最小结构：
+
+```text
+person_encoder(A_obs) -> h_A
+person_encoder(B_obs) -> h_B
+relation_encoder(relation_features) -> h_rel
+fuse(h_A, h_B, h_rel) -> joint decoder -> future(A,B)
+```
+
+允许的 relation encoder：
+
+```text
+GRU
+MLP over temporal pooled relation features
+small TransformerEncoder if PyTorch 1.7.1 支持路径稳定
+```
+
+第一版优先：
+
+```text
+GRU relation encoder
+```
+
+### Loss
+
+第一次训练：
+
+```text
+normalized active-vector MSE
+```
+
+之后可做 ablation：
+
+```text
++ relative_root_distance_loss
++ relative_orientation_loss
+```
+
+### 验收标准
+
+P4 通过条件：
+
+```text
+relation-aware smoke 通过
+relation-aware test metrics 完整输出
+relation-aware future_mse 不差于 concat
+relation-aware long_mse 优于 concat
+relation-aware 交互指标优于 concat 或 independent
+```
+
+最低论文主张门槛：
+
+```text
+long_mse 和至少一个 relation metric 明显优于 concat no-relation。
+```
+
+如果只在 future_mse 上微弱变化，不能声称关系建模有效。
+
+### 失败回退
+
+如果 relation-aware 不优于 concat：
+
+```text
+1. 检查 relation features 是否正确。
+2. 检查 concat baseline 是否过强但无 relation 指标提升。
+3. 加 relation loss 做 ablation。
+4. 增加 cross-attention。
+5. 最后才考虑 graph network。
+```
+
+不能直接进入论文包装。
+
+### 阶段记录
+
+P4 完成后必须新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p4-relation-result.md
+```
+
+记录：
+
+```text
+relation features
+模型配置
+训练命令
+checkpoint
+与 P3 baselines 的完整对比
+是否满足论文主张门槛
+是否偏离本路线图
+```
+
+## P5：Ablation + Paper Tables
+
+### 目标
+
+证明 relation-aware 不是偶然变好，并整理论文可用表格。
+
+### 必做 ablation
+
+结构消融：
+
+```text
+without relation encoder
+with relation encoder
+```
+
+关系特征消融：
+
+```text
+relative translation only
+relative orientation only
+relative velocity only
+all relation features
+```
+
+观测比例消融：
+
+```text
+10%: obs=15, pred=135
+20%: obs=30, pred=120
+30%: obs=45, pred=105
+50%: obs=75, pred=75
+```
+
+主表仍以 20% 为主协议。
+
+### 可选 ablation
+
+```text
+hidden_dim 256 / 512
+GRU vs small Transformer
+with / without relation loss
+```
+
+### 论文表格
+
+主结果表：
+
+```text
+Repeat
+Independent
+Concat no-relation
+Relation-aware
+```
+
+列：
+
+```text
+future_mse
+rotation_mse
+translation_mse
+long_mse
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+Ablation 表：
+
+```text
+relation feature set
+future_mse
+long_mse
+relation metrics
+```
+
+观测比例表：
+
+```text
+obs ratio
+independent
+concat
+ours
+```
+
+### 验收标准
+
+P5 通过条件：
+
+```text
+所有表格指标来自同一个 eval_forecasting 协议。
+所有实验记录 checkpoint 和 args。
+主表支持论文核心主张。
+ablation 支持 relation features 的必要性。
+```
+
+### 失败回退
+
+如果 ablation 不支持主张：
+
+```text
+回到 P4 模型设计。
+不要只挑选有利指标。
+```
+
+如果观测比例不稳定：
+
+```text
+先固定 20% 主协议。
+其他比例作为补充，不影响第一阶段主线。
+```
+
+### 阶段记录
+
+P5 完成后必须新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p5-ablation-tables.md
+```
+
+记录：
+
+```text
+所有实验清单
+表格数据源
+是否满足论文主张
+失败或不稳定实验
+是否偏离本路线图
+```
+
+## P6：Visualization + Qualitative Analysis
+
+### 目标
+
+用定性结果解释模型如何改善双人关系，而不是只报告 MSE。
+
+### 任务
+
+实现或复用：
+
+```text
+active vector -> H5-like [T,25,12]
+H5-like -> render / rot2xyz 输入
+obs / gt / pred 对比保存
+relative root distance curve
+relative orientation curve
+```
+
+可视化样本：
+
+```text
+至少 8 个 test samples
+覆盖短序列边界和长序列
+覆盖 relation-aware 明显优于 concat 的样本
+覆盖 relation-aware 失败样本
+```
+
+### 输出
+
+```text
+results/forecasting/interhuman/{run_name}/
+```
+
+建议内容：
+
+```text
+sample_id
+obs.npy
+gt.npy
+pred_repeat.npy
+pred_concat.npy
+pred_relation.npy
+distance_curve.png
+orientation_curve.png
+rendered videos or frame sequences
+```
+
+### 验收标准
+
+P6 通过条件：
+
+```text
+至少 8 个样本可视化输出。
+所有 pred 数值有限。
+obs / gt / pred 时间轴对齐。
+distance / orientation 曲线与 metrics 一致。
+失败样本也被记录，而不是只保留成功样本。
+```
+
+### 失败回退
+
+如果 render 链路卡住：
+
+```text
+先输出 npy + 曲线图。
+不要让渲染阻塞论文主指标。
+```
+
+如果可视化显示动作崩坏但 MSE 低：
+
+```text
+回到 P4/P5，检查指标是否遗漏关键关系质量。
+```
+
+### 阶段记录
+
+P6 完成后必须新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p6-qualitative-result.md
+```
+
+记录：
+
+```text
+样本列表
+输出路径
+成功案例
+失败案例
+图表说明
+是否偏离本路线图
+```
+
+## 阶段间全局记录要求
+
+每个阶段实现完成后必须记录：
+
+```text
+1. 本阶段引用的路线图文件。
+2. 实际实现文件。
+3. 是否偏离原计划。
+4. 偏离原因。
+5. 验收命令。
+6. 验收结果。
+7. 下一阶段是否允许开始。
+```
+
+如果任何阶段未达到验收标准：
+
+```text
+不能把状态写为完成。
+不能进入下一阶段做论文结论。
+可以做修复文档和修复实现。
+```
+
+## 最短执行顺序
+
+推荐执行：
+
+```text
+1. P1 dataset + normalizer smoke
+2. P2 metrics + repeat baseline
+3. P3 concat baseline
+4. P3 independent baseline
+5. P4 relation-aware model
+6. P5 main table
+7. P5 ablations
+8. P6 qualitative analysis
+```
+
+原因：
+
+```text
+concat baseline 最接近 relation-aware 的公平对照；
+如果 concat baseline 都无法赢 repeat，关系模型没有实现意义。
+```
+
+## 当前下一步
+
+下一步允许开始 P1，但必须以本文件为原始路线图，并且实现前引用 P1/P2 详细设计：
+
+```text
+docs/ai/context/20260603-161334-forecasting-p1-p2-design.md
+```
+
+P1 实现期间不得修改：
+
+```text
+train/train_mdm.py
+model/cmdm.py
+diffusion/gaussian_diffusion.py
+eval/eval_cmdm.py
+```
+
+除非新文档明确说明旧 ReGenNet 路径需要被纳入扩展阶段。

--- a/docs/ai/context/20260603-182845-forecasting-roadmap-feasibility-review.md
+++ b/docs/ai/context/20260603-182845-forecasting-roadmap-feasibility-review.md
@@ -1,0 +1,252 @@
+# Forecasting P1-P6 路线图可行性审阅
+
+## 审阅定位
+
+本次按 `$academic-paper` 的 plan / structure / argumentation 视角审阅：
+
+```text
+docs/ai/context/20260603-161803-forecasting-p1-p6-roadmap.md
+```
+
+审阅目标不是实现 P1-P6，而是判断当前项目条件下该路线图是否能支撑一篇经验型方法论文的第一阶段。
+
+## 结论
+
+总体判断：
+
+```text
+工程可行性：中高
+论文主张可行性：有条件成立
+当前是否允许进入 P1：允许
+当前是否允许跳到 P3/P4：不允许
+```
+
+路线图的强点是任务边界收得足够窄，先做 InterHuman deterministic forecasting，先闭环 dataset / metrics / repeat baseline，再进入模型和 ablation。这符合经验型方法论文的 IMRaD 结构，也避免继续被 ReGenNet Table 4、SMPL-X、text condition 和 recognition evaluator 阻塞。
+
+核心保留意见是：relation-aware model 是否能形成论文贡献，必须由 P4/P5 的对照实验证明。只要 long_mse 和至少一个 relation metric 不能稳定优于 concat no-relation baseline，就不能把路线图包装成成功论文。
+
+## 本地事实核对
+
+已确认本地可用环境：
+
+```text
+micromamba env: /home/rpartx3080/.local/micromamba/envs/regennet
+python: 3.7.13
+torch: 1.7.1
+cuda_available: True
+h5py: 3.7.0
+```
+
+裸系统 `python3` 缺少 `h5py`，因此后续 smoke / eval 命令应显式使用 regennet 环境。
+
+已确认 H5 数据与路线图一致：
+
+```text
+format: [T,25,12]
+translation_slot: 24
+translation_origin: actor frame 0
+
+train: total 6021, T>=150 2910, bad_shape 0
+val:   total 580,  T>=150 226,  bad_shape 0
+test:  total 1175, T>=150 508,  bad_shape 0
+```
+
+当前 forecasting 专用文件尚不存在：
+
+```text
+data_loaders/forecasting/*
+utils/forecasting_motion.py
+utils/forecasting_metrics.py
+eval/eval_forecasting.py
+model/forecasting.py
+train/train_forecasting.py
+```
+
+这与路线图的“下一步从 P1 开始”一致。
+
+## 论文结构可行性
+
+推荐论文结构应是 IMRaD：
+
+```text
+Introduction: 双人未来预测中 interaction-aware inductive bias 的必要性。
+Method: InterHuman fixed-window forecasting protocol、active vector、relation-aware predictor。
+Results: repeat / independent / concat / relation-aware 和 ablation。
+Discussion: relation-aware 何时有效、何时失败、deterministic forecasting 的边界。
+```
+
+路线图已经具备 Method 和 Results 的基本骨架，但 Literature Review 仍缺位。工程 P1/P2 不需要等待文献综述，但写论文前必须补齐 two-person motion forecasting、human interaction generation / prediction、relation modeling / graph / social forecasting 相关工作矩阵。
+
+## 阶段可行性审阅
+
+### P1 Dataset + Normalizer
+
+可行。H5 shape、样本数、active vector 映射都有本地依据。
+
+需要补强：
+
+```text
+1. 验收命令明确使用 regennet micromamba 环境。
+2. 明确 normalizer 统计口径：T>=150 全序列所有帧，还是可采样 150-window 分布。
+3. 明确是否保留 frozen H5 的 actor-frame-0 坐标；如果后续改成 window recenter，必须作为协议变更记录。
+```
+
+建议第一版保留当前 frozen H5 坐标，不在 P1 引入 window recenter，以免扩大实现面。
+
+### P2 Metrics + Repeat Baseline
+
+可行，而且必须优先做。`pred == target` sanity check 是防止后续模型结果无意义的关键。
+
+需要补强：
+
+```text
+1. relative_orientation_error 中 acos 前必须 clamp，避免浮点误差产生 NaN。
+2. predicted rot6d 需要通过 rotation_6d_to_matrix 正交化后再算相对角度。
+3. inter_person_distance_consistency 当前是 root distance delta，适合作为第一版指标，但论文中不能把它说成完整的 interaction quality。
+```
+
+### P3 Independent / Concat Baselines
+
+可行。Independent 和 concat 的定义清楚，concat 是 relation-aware 的关键强基线。
+
+需要补强：
+
+```text
+1. 报告参数量和训练预算，避免 relation-aware 只是因为更大而赢。
+2. Independent 必须严格隔离 A/B observation。
+3. Concat 不显式构造 relation features，但它可以从 raw obs 学到关系；论文表述应是“显式关系归纳偏置是否优于原始拼接”，不是“concat 完全没有关系信息”。
+```
+
+P3 只要求优于 repeat baseline 合理；如果 concat 都赢不了 repeat，说明数据、normalizer、target 对齐或训练设置有根本问题。
+
+### P4 Relation-Aware Predictor
+
+方向可行，但这是论文成败点。
+
+关系特征选择合理：
+
+```text
+relative root translation
+relative velocity
+root distance
+relative root orientation
+```
+
+需要补强：
+
+```text
+1. 做 parameter-matched ablation，区分 relation feature 贡献和额外参数贡献。
+2. 若 relation-aware 只在 future_mse 微弱提升，不能声称 interaction-aware 有效。
+3. 若只赢 independent、不赢 concat，论文贡献不成立。
+```
+
+最低成立条件应保持路线图原判断：
+
+```text
+long_mse 优于 concat
+至少一个 relation metric 优于 concat
+```
+
+### P5 Ablation + Paper Tables
+
+方向可行，但路线图目前缺少重复实验要求。
+
+必须新增：
+
+```text
+主结果至少 3 个 seed，表格报告 mean/std 或 mean±std。
+所有模型使用同一 eval_forecasting 协议。
+所有 checkpoint、args、metrics 可回溯。
+```
+
+如果单 seed 结果被当作主表，论文证据链偏弱。
+
+### P6 Visualization + Qualitative Analysis
+
+可行。P6 应作为解释和失败案例分析，不应替代主指标。
+
+需要补强：
+
+```text
+1. 失败样本必须保留。
+2. 可视化优先输出 npy 和 relation curves；render 卡住时不能阻塞主结果。
+3. 如果可视化显示动作崩坏但 MSE 低，应回头补指标，而不是继续写定性描述。
+```
+
+## 主要风险
+
+### 风险 1：确定性预测对多模态未来过强约束
+
+150 帧窗口、30 帧观测、120 帧预测是高难度 deterministic setting。模型可能倾向平均动作，长期预测会自然变差。
+
+处理方式：
+
+```text
+第一阶段只声称验证 relation-aware deterministic forecasting。
+best-of-K、diversity、多模态生成放到后续扩展。
+```
+
+### 风险 2：concat baseline 可能已经足够强
+
+concat 能看到两个人全部历史，因此它不是弱 baseline。relation-aware 的贡献必须是更好的归纳偏置，而不是“首次使用双人信息”。
+
+处理方式：
+
+```text
+以 concat 为主对照。
+加入参数匹配和 relation feature ablation。
+不把赢 independent 当作核心贡献。
+```
+
+### 风险 3：SMPL reproduction 口径限制
+
+当前 H5 是 SMPL / rot6d 表示，不是 SMPL-X 官方 InterHuman 口径。
+
+处理方式：
+
+```text
+论文中明确这是 SMPL reproduction / first-stage protocol。
+不要声称完全复现官方 InterHuman / InterGen 表示。
+```
+
+### 风险 4：缺少文献和 novelty 证据链
+
+路线图能支撑实验，但不能单独支撑论文 novelty。
+
+处理方式：
+
+```text
+P1/P2 可立即做。
+P3/P4 期间并行补 literature matrix。
+写论文前必须明确与 two-person forecasting / interaction generation / social prediction 的差异。
+```
+
+## 建议的路线图修订
+
+不建议推翻原路线图。建议只追加以下约束：
+
+```text
+1. 所有 smoke/eval 命令显式使用 regennet micromamba 环境。
+2. P2 relative orientation 指标加入 clamp 和 rot6d 正交化要求。
+3. P3/P4 记录参数量、训练预算、seed。
+4. P5 主表至少 3 seed，报告 mean/std。
+5. P4/P5 明确 concat 是核心对照，relation-aware 必须赢 concat 才能支撑主张。
+6. 文献综述并行推进，但不阻塞 P1/P2 工程闭环。
+```
+
+## 是否允许进入下一步
+
+允许进入 P1：
+
+```text
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+utils/forecasting_motion.py
+```
+
+但 P1/P2 完成前仍不应实现 relation-aware model。当前最正确的下一步仍是：
+
+```text
+P1 active vector + dataset + normalizer smoke
+P2 metrics + repeat baseline evaluator
+```

--- a/docs/ai/context/20260603-184214-forecasting-p1-p6-complete-design.md
+++ b/docs/ai/context/20260603-184214-forecasting-p1-p6-complete-design.md
@@ -1,0 +1,1388 @@
+# Forecasting P1-P6 完整设计文档
+
+## 文档定位
+
+本文件使用 `using-superpowers` 工作流整理，是 P1-P6 的工程设计 contract。它细化以下上游文档，但不覆盖原始路线图：
+
+```text
+docs/ai/context/20260603-160713-forecasting-final-goal-design.md
+docs/ai/context/20260603-161334-forecasting-p1-p2-design.md
+docs/ai/context/20260603-161803-forecasting-p1-p6-roadmap.md
+docs/ai/context/20260603-182845-forecasting-roadmap-feasibility-review.md
+```
+
+原始路线图仍是第一阶段上位目标。后续每个阶段实现完成时，必须新建阶段结果文档，不得覆盖本文件或路线图。
+
+## 总目标
+
+论文第一阶段目标：
+
+```text
+Interaction-aware joint forecasting of two-person human motion from partial observations.
+```
+
+中文：
+
+```text
+基于部分观测的交互感知双人动作联合未来预测。
+```
+
+固定主协议：
+
+```text
+dataset: InterHuman
+representation: SMPL reproduction active vector
+window_len: 150
+obs_len: 30
+pred_len: 120
+input: 前 30 帧双人动作
+target: 后 120 帧双人动作
+output: 两个人未来动作联合预测
+task_type: deterministic forecasting
+```
+
+核心可证伪假设：
+
+```text
+显式建模两人关系应优于 independent predictor 和 concat no-relation predictor，
+尤其应改善 long-horizon error 和 inter-person relation metrics。
+```
+
+如果 relation-aware model 不能稳定优于 concat no-relation baseline，则论文主张不成立，不能进入包装结论。
+
+## 本地约束
+
+必须使用项目环境：
+
+```text
+micromamba env: /home/rpartx3080/.local/micromamba/envs/regennet
+python: 3.7.13
+torch: 1.7.1
+h5py: 3.7.0
+cuda: available
+```
+
+裸系统 `python3` 缺少 `h5py`，后续命令必须显式使用：
+
+```text
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python ...
+```
+
+数据事实：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+
+format: [T,25,12]
+body_model: smpl
+rotation: rot6d
+translation_slot: 24
+translation_origin: actor frame 0
+
+train: total 6021, T>=150 2910
+val:   total 580,  T>=150 226
+test:  total 1175, T>=150 508
+```
+
+第一阶段不修改旧 ReGenNet 主路径：
+
+```text
+train/train_mdm.py
+model/cmdm.py
+diffusion/gaussian_diffusion.py
+eval/eval_cmdm.py
+```
+
+原因是旧路径绑定 diffusion、actor condition / reactor target 和 ST-GCN evaluator，不符合 prefix-to-future forecasting 语义。
+
+## 全局边界
+
+第一阶段只做：
+
+```text
+InterHuman 150-frame deterministic two-person forecasting
+active vector 表示
+train split normalizer
+统一 MSE 类和交互关系指标
+repeat / independent / concat / relation-aware 对照
+ablation 和 qualitative analysis
+```
+
+第一阶段不做：
+
+```text
+ReGenNet Table 4 完整复现
+自然语言条件预测
+动作标签条件预测
+SMPL-X 转换
+ST-GCN recognition evaluator
+diffusion forecasting
+best-of-K / diversity / multimodal sampling
+NTU120-AS / Chi3D 泛化
+```
+
+这些内容可以作为 P7+，不得阻塞 P1-P6。
+
+## 阶段依赖
+
+唯一允许顺序：
+
+```text
+P1 Dataset + Normalizer
+  -> P2 Metrics + Repeat Baseline
+    -> P3 Independent / Concat Baselines
+      -> P4 Relation-Aware Predictor
+        -> P5 Ablation + Paper Tables
+          -> P6 Visualization + Qualitative Analysis
+```
+
+禁止跳过：
+
+```text
+P1/P2 未完成，不实现 P3。
+P3 未完成，不实现 P4。
+P4 未完成，不写 P5 主结论。
+P5 未完成，不把 P6 可视化作为主证明。
+```
+
+## 目录设计
+
+新增 forecasting 专用路径：
+
+```text
+data_loaders/forecasting/__init__.py
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+utils/forecasting_motion.py
+utils/forecasting_metrics.py
+model/forecasting.py
+train/train_forecasting.py
+eval/eval_forecasting.py
+sample/visualize_forecasting.py
+```
+
+保存路径：
+
+```text
+save/forecasting/interhuman/{run_name}/
+results/forecasting/interhuman/{run_name}/
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p{N}-*.md
+```
+
+文件职责：
+
+```text
+interhuman.py: H5 读取、T>=150 过滤、窗口裁剪、dataset item。
+tensors.py: forecasting collate，不做 padding。
+forecasting_motion.py: active vector extract/restore、normalizer、relation feature 基础函数。
+forecasting_metrics.py: 原始尺度指标。
+forecasting.py: independent / concat / relation-aware 模型。
+train_forecasting.py: supervised 训练、checkpoint、val/test eval。
+eval_forecasting.py: repeat baseline 和 checkpoint 评估入口。
+visualize_forecasting.py: npy、曲线、可选 render 输出。
+```
+
+## 统一数据表示
+
+H5 输入：
+
+```text
+motion: [T, 25, 12]
+actor_rot6d:         motion[:, :24, 0:6]
+actor_translation:   motion[:, 24, 0:3]
+reactor_rot6d:       motion[:, :24, 6:12]
+reactor_translation: motion[:, 24, 6:9]
+```
+
+active vector：
+
+```text
+person_dim = 24 * 6 + 3 = 147
+two_person_dim = 2 * 147 = 294
+motion_active: [T, 2, 147]
+motion_active[:, 0, :144] = actor_rot6d.reshape(T, 144)
+motion_active[:, 0, 144:147] = actor_translation
+motion_active[:, 1, :144] = reactor_rot6d.reshape(T, 144)
+motion_active[:, 1, 144:147] = reactor_translation
+```
+
+窗口：
+
+```text
+window: [150, 2, 147]
+obs:    [30, 2, 147]
+target: [120, 2, 147]
+```
+
+active vector restore：
+
+```text
+motion[:, :24, 0:6] = active[:, 0, :144].reshape(T, 24, 6)
+motion[:, 24, 0:3] = active[:, 0, 144:147]
+motion[:, :24, 6:12] = active[:, 1, :144].reshape(T, 24, 6)
+motion[:, 24, 6:9] = active[:, 1, 144:147]
+其他 channel 保持 0
+```
+
+第一版保留 frozen H5 的 `actor frame 0` 坐标，不做 window recenter。若后续改为 window recenter，必须作为协议变更记录。
+
+## Normalizer Contract
+
+统计来源：
+
+```text
+split: train only
+samples: T>=150 的 train sequences
+frames: 每条可用序列的全部帧
+space: active vector original scale
+```
+
+张量形状：
+
+```text
+mean: [1, 1, 2, 147]
+std:  [1, 1, 2, 147]
+eps:  1e-6
+std < eps 的维度设为 1.0
+```
+
+接口：
+
+```text
+normalize(x) = (x - mean) / std
+denormalize(x) = x * std + mean
+```
+
+保存：
+
+```text
+normalizer.pt
+normalizer.json
+```
+
+`normalizer.json` 至少包含：
+
+```text
+dataset
+data_path
+window_len
+obs_len
+pred_len
+num_train_sequences_used
+num_train_frames_used
+person_dim
+eps
+created_at
+```
+
+训练 loss 使用 normalized space。论文指标只使用 original scale。
+
+## Metrics Contract
+
+输入：
+
+```text
+pred:   Tensor[B, 120, 2, 147]
+target: Tensor[B, 120, 2, 147]
+obs:    Tensor[B, 30, 2, 147]
+```
+
+所有输入必须是 original scale。
+
+输出 key 固定：
+
+```text
+future_mse
+rotation_mse
+translation_mse
+short_mse
+mid_mse
+long_mse
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+定义：
+
+```text
+future_mse = mean((pred - target)^2)
+rotation_mse = mean((pred[..., :144] - target[..., :144])^2)
+translation_mse = mean((pred[..., 144:147] - target[..., 144:147])^2)
+short_mse = future_mse over pred frames 0:40
+mid_mse = future_mse over pred frames 40:80
+long_mse = future_mse over pred frames 80:120
+```
+
+相对距离：
+
+```text
+trans_A = x[:, :, 0, 144:147]
+trans_B = x[:, :, 1, 144:147]
+dist = norm(trans_A - trans_B, dim=-1)
+relative_root_distance_error = mean(abs(pred_dist - target_dist))
+```
+
+相对朝向：
+
+```text
+root_A = x[:, :, 0, 0:6]
+root_B = x[:, :, 1, 0:6]
+R_A = rotation_6d_to_matrix(root_A)
+R_B = rotation_6d_to_matrix(root_B)
+R_rel = R_A.transpose(-1, -2) @ R_B
+R_err = R_rel_pred.transpose(-1, -2) @ R_rel_target
+angle = acos(clamp((trace(R_err) - 1) / 2, -1 + eps, 1 - eps))
+relative_orientation_error = mean(angle)
+```
+
+`rotation_6d_to_matrix` 必须用于正交化预测 rot6d，`acos` 前必须 clamp，避免浮点 NaN。
+
+相对距离变化一致性：
+
+```text
+dist_full_pred = concat(last_obs_dist, pred_dist)
+dist_full_target = concat(last_obs_dist, target_dist)
+delta_pred = dist_full_pred[:, 1:] - dist_full_pred[:, :-1]
+delta_target = dist_full_target[:, 1:] - dist_full_target[:, :-1]
+inter_person_distance_consistency = mean(abs(delta_pred - delta_target))
+```
+
+注意：这个指标只能表述为 root distance trend consistency，不能声称覆盖完整 interaction quality。
+
+## P1 设计：Dataset + Normalizer
+
+### 目标
+
+建立唯一 forecasting 数据协议，保证所有 baseline 和模型读取完全一致的 `obs / target`。
+
+### 新增文件
+
+```text
+data_loaders/forecasting/__init__.py
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+utils/forecasting_motion.py
+```
+
+### 核心类与函数
+
+```text
+InterHumanForecastDataset(
+    data_path,
+    split,
+    window_len=150,
+    obs_len=30,
+    pred_len=120,
+    max_samples=-1,
+    seed=0,
+)
+
+forecasting_collate(batch) -> (obs, target, meta)
+extract_active_motion(motion_h5) -> active
+restore_active_motion(active) -> motion_h5_like
+compute_forecasting_normalizer(data_path, save_path, ...)
+load_forecasting_normalizer(path)
+```
+
+### Dataset item
+
+```text
+{
+  "obs": Tensor[30, 2, 147],
+  "target": Tensor[120, 2, 147],
+  "sample_id": str,
+  "start": int,
+  "length": int,
+}
+```
+
+### Batch
+
+```text
+obs:    Tensor[B, 30, 2, 147]
+target: Tensor[B, 120, 2, 147]
+meta:   list[dict]
+```
+
+### 采样规则
+
+训练：
+
+```text
+保留 T>=150。
+每次 __getitem__ 随机选择 start in [0, T - 150]。
+同一样本多次读取 start 可以变化。
+```
+
+验证/测试：
+
+```text
+保留 T>=150。
+start = floor((T - 150) / 2)。
+同一样本多次读取 start 固定。
+```
+
+不做 padding。短序列不进入第一阶段协议。
+
+### P1 验收
+
+必须通过：
+
+```text
+train dataset length = 2910
+val dataset length = 226
+test dataset length = 508
+obs shape = [30,2,147]
+target shape = [120,2,147]
+所有 obs/target 数值有限
+train 同一样本多次读取 start 可变化
+val/test 同一样本多次读取 start 固定
+normalizer 可保存和加载
+normalize -> denormalize 最大误差在浮点容忍范围内
+active -> h5-like -> active 最大误差在浮点容忍范围内
+```
+
+建议验收入口：
+
+```text
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m eval.eval_forecasting \
+  --mode dataset_smoke \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --window_len 150 \
+  --obs_len 30 \
+  --pred_len 120 \
+  --batch_size 4 \
+  --num_workers 0
+```
+
+### P1 失败回退
+
+```text
+shape 错：先查 active vector 映射，再查 collate。
+样本数错：先查 T>=150 过滤，再查 split 文件。
+数值异常：先查 H5 finite，再查 std 防护。
+eval start 不固定：修 dataset，不进入 P2。
+```
+
+### P1 阶段记录
+
+完成后新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p1-dataset-result.md
+```
+
+记录：
+
+```text
+引用路线图和本设计文件
+实现文件
+shape 检查
+样本数
+normalizer 摘要
+smoke 命令和结果
+是否允许进入 P2
+```
+
+## P2 设计：Metrics + Repeat Baseline
+
+### 目标
+
+在训练模型前完成评估闭环，确保后续所有结果可比较。
+
+### 新增文件
+
+```text
+utils/forecasting_metrics.py
+eval/eval_forecasting.py
+```
+
+### Repeat baseline
+
+定义：
+
+```text
+pred[:, t] = obs[:, -1]
+```
+
+repeat 不是论文贡献，只是 sanity baseline 和最低对照。
+
+### 评估入口
+
+`eval/eval_forecasting.py` 支持：
+
+```text
+--mode dataset_smoke
+--mode metrics_sanity
+--mode repeat
+--mode checkpoint
+```
+
+repeat 命令：
+
+```text
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m eval.eval_forecasting \
+  --mode repeat \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --split test \
+  --window_len 150 \
+  --obs_len 30 \
+  --pred_len 120 \
+  --batch_size 64 \
+  --num_workers 0 \
+  --save_dir save/forecasting/interhuman/repeat_150_30_120
+```
+
+输出：
+
+```text
+save/forecasting/interhuman/repeat_150_30_120/metrics_test.json
+save/forecasting/interhuman/repeat_150_30_120/metrics_test.yaml
+```
+
+### P2 验收
+
+必须通过：
+
+```text
+pred == target 时 MSE 类指标为 0。
+pred == target 时 relative_root_distance_error 为 0。
+pred == target 时 relative_orientation_error 接近 0。
+repeat baseline 可完整评估 test split。
+repeat baseline 输出固定 metrics key。
+metrics 文件可被 P3/P4/P5 复用。
+```
+
+### P2 失败回退
+
+```text
+pred == target 非 0：修 metrics，不进入 P3。
+relative_orientation_error NaN：检查 rot6d_to_matrix、trace clamp、eps。
+repeat 跑不完：修 dataset / collate / dataloader。
+metrics key 不稳定：固定 schema，不进入模型训练。
+```
+
+### P2 阶段记录
+
+完成后新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p2-metrics-repeat-result.md
+```
+
+记录：
+
+```text
+sanity check 结果
+repeat baseline test 指标
+metrics 文件路径
+是否允许进入 P3
+```
+
+## P3 设计：Independent / Concat Baselines
+
+### 目标
+
+建立两个可训练 baseline，证明 relation-aware 不是只赢 repeat baseline。
+
+### 新增文件
+
+```text
+model/forecasting.py
+train/train_forecasting.py
+```
+
+### 共享训练 contract
+
+输入：
+
+```text
+obs:    [B, 30, 2, 147]
+target: [B, 120, 2, 147]
+```
+
+训练：
+
+```text
+loss = MSE(pred_normalized, target_normalized)
+optimizer = AdamW
+num_steps 表示 optimizer steps
+grad_accum_steps 支持梯度累积
+num_workers 默认 0
+```
+
+保存：
+
+```text
+args.json
+normalizer.pt
+normalizer.json
+model{step:09}.pt
+opt{step:09}.pt
+metrics_val.json / yaml
+metrics_test.json / yaml
+```
+
+日志至少包含：
+
+```text
+step
+train_loss
+val_future_mse
+effective_batch_size
+model_num_params
+seed
+```
+
+### Baseline 1：Independent Predictor
+
+定义：
+
+```text
+A_obs -> A_future
+B_obs -> B_future
+concat(A_future, B_future)
+```
+
+硬约束：
+
+```text
+A 分支不能读 B_obs。
+B 分支不能读 A_obs。
+```
+
+建议结构：
+
+```text
+person_encoder: GRU(input_dim=147, hidden_dim=256/512, num_layers=2)
+decoder: MLP(hidden_dim -> pred_len * 147)
+参数可共享，也可 two-tower；第一版优先共享 encoder/decoder，减少参数。
+```
+
+输出：
+
+```text
+pred: [B, 120, 2, 147]
+```
+
+### Baseline 2：Concat No-Relation Predictor
+
+定义：
+
+```text
+concat(A_obs, B_obs) -> future(A, B)
+```
+
+约束：
+
+```text
+可以看到双人原始历史。
+不能显式构造 relation features。
+不能使用 relation_encoder。
+```
+
+建议结构：
+
+```text
+encoder: GRU(input_dim=294, hidden_dim=256/512, num_layers=2)
+decoder: MLP(hidden_dim -> pred_len * 294)
+```
+
+论文表述必须准确：concat 不是“没有关系信息”，而是“没有显式关系归纳偏置”。
+
+### 训练命令草案
+
+concat smoke：
+
+```text
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m train.train_forecasting \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --save_dir save/forecasting/interhuman/concat_smoke \
+  --model_type concat \
+  --window_len 150 \
+  --obs_len 30 \
+  --pred_len 120 \
+  --batch_size 8 \
+  --num_steps 5 \
+  --hidden_dim 256 \
+  --num_layers 2 \
+  --lr 1e-3 \
+  --grad_accum_steps 1 \
+  --max_samples 64 \
+  --num_workers 0 \
+  --seed 0
+```
+
+independent smoke 同上，`--model_type independent`。
+
+### P3 验收
+
+必须通过：
+
+```text
+independent max_samples smoke 通过。
+concat max_samples smoke 通过。
+两个模型都保存 checkpoint / args / normalizer。
+两个模型都能在 val/test 输出 P2 固定 metrics。
+两个模型至少优于 repeat baseline 的 future_mse。
+记录模型参数量、训练预算、seed。
+concat 与 independent 的差异可解释。
+```
+
+### P3 失败回退
+
+```text
+loss 不下降：检查 normalizer、target 错位、decoder reshape。
+checkpoint 不能加载：先修保存/加载，不进入 P4。
+模型赢不了 repeat：先检查训练协议，不直接加复杂模型。
+independent 泄漏另一人信息：修模型输入切分，重跑结果。
+```
+
+### P3 阶段记录
+
+完成后新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p3-baselines-result.md
+```
+
+记录：
+
+```text
+模型配置
+参数量
+训练命令
+checkpoint
+val/test metrics
+repeat / independent / concat 对比表
+是否允许进入 P4
+```
+
+## P4 设计：Relation-Aware Joint Predictor
+
+### 目标
+
+实现论文核心模型：显式关系推理 + 双人联合未来预测。
+
+### 关系特征
+
+从 `obs` 中提取：
+
+```text
+trans_A = obs[:, :, 0, 144:147]
+trans_B = obs[:, :, 1, 144:147]
+relative_root_translation = trans_A - trans_B                # [B,30,3]
+velocity_A = trans_A[:, 1:] - trans_A[:, :-1]
+velocity_B = trans_B[:, 1:] - trans_B[:, :-1]
+relative_root_velocity = velocity_A - velocity_B             # [B,29,3]
+root_distance = norm(relative_root_translation, dim=-1)       # [B,30,1]
+relative_root_orientation = matrix_to_rotation_6d(R_A^T R_B) # [B,30,6]
+```
+
+为了 temporal length 对齐，velocity 第一帧补 0 或复制第一段速度。第一版优先补 0，并记录在 args。
+
+relation feature 最小拼接：
+
+```text
+rel_feat: [B, 30, 13]
+3 translation + 3 velocity + 1 distance + 6 relative orientation
+```
+
+### 模型结构
+
+第一版：
+
+```text
+person_encoder(A_obs) -> h_A
+person_encoder(B_obs) -> h_B
+relation_encoder(rel_feat) -> h_rel
+fuse([h_A, h_B, h_rel]) -> joint_decoder -> pred [B,120,2,147]
+```
+
+建议模块：
+
+```text
+person_encoder: shared GRU(input_dim=147, hidden_dim=256/512, num_layers=2)
+relation_encoder: GRU(input_dim=13, hidden_dim=128/256, num_layers=1/2)
+fusion: concat + MLP
+decoder: MLP(fused_dim -> pred_len * 294)
+```
+
+第一版不使用 graph network。只有当 relation-aware 不能赢 concat 且特征/训练已排查后，才考虑 cross-attention 或 graph。
+
+### 参数公平性
+
+必须记录：
+
+```text
+independent_num_params
+concat_num_params
+relation_num_params
+training_steps
+effective_batch_size
+seed
+```
+
+P5 中必须加入 parameter-matched 或 no-relation-encoder ablation，避免 relation-aware 只是参数更多。
+
+### Loss
+
+主训练：
+
+```text
+loss = normalized active-vector MSE
+```
+
+可选 ablation：
+
+```text
+loss += lambda_dist * relative_root_distance_loss
+loss += lambda_orient * relative_orientation_loss
+```
+
+第一版不在主模型加入 relation loss。先看同一 reconstruction loss 下 relation architecture 是否有效。
+
+### P4 验收
+
+必须通过：
+
+```text
+relation-aware smoke 通过。
+relation-aware checkpoint 可加载。
+relation-aware test metrics 完整输出。
+relation-aware future_mse 不差于 concat。
+relation-aware long_mse 优于 concat。
+relation-aware 至少一个 relation metric 优于 concat。
+记录 relation features、参数量、训练预算、seed。
+```
+
+论文主张最低门槛：
+
+```text
+long_mse 和至少一个 relation metric 明显优于 concat no-relation。
+```
+
+如果只赢 independent、不赢 concat，不能声称 relation-aware joint modeling 成立。
+
+### P4 失败回退
+
+```text
+先检查 relation feature 数值和 shape。
+再检查 concat baseline 是否公平且参数量接近。
+再加入 relation loss 做 ablation。
+再考虑 cross-attention。
+最后才考虑 graph network。
+```
+
+不得在 P4 失败时直接进入论文包装。
+
+### P4 阶段记录
+
+完成后新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p4-relation-result.md
+```
+
+记录：
+
+```text
+relation features
+模型配置
+参数量
+训练命令
+checkpoint
+与 P3 baselines 的完整对比
+是否满足论文主张门槛
+是否允许进入 P5
+```
+
+## P5 设计：Ablation + Paper Tables
+
+### 目标
+
+证明 relation-aware 不是偶然变好，生成论文可用主表和消融表。
+
+### 实验矩阵
+
+主实验：
+
+```text
+Repeat
+Independent
+Concat no-relation
+Relation-aware
+```
+
+主协议：
+
+```text
+window_len=150
+obs_len=30
+pred_len=120
+```
+
+重复实验：
+
+```text
+至少 3 seeds: 0, 1, 2
+报告 mean/std 或 mean±std
+```
+
+结构消融：
+
+```text
+concat no-relation
+relation-aware without relation encoder
+relation-aware with relation encoder
+parameter-matched concat
+```
+
+关系特征消融：
+
+```text
+relative translation only
+relative velocity only
+relative orientation only
+translation + velocity
+all relation features
+```
+
+观测比例消融：
+
+```text
+10%: obs=15, pred=135
+20%: obs=30, pred=120
+30%: obs=45, pred=105
+50%: obs=75, pred=75
+```
+
+20% 是主协议，其他比例是补充结果。
+
+可选：
+
+```text
+hidden_dim 256 / 512
+with / without relation loss
+GRU vs small TransformerEncoder
+```
+
+### 表格设计
+
+主结果表列：
+
+```text
+method
+params
+future_mse
+rotation_mse
+translation_mse
+long_mse
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+消融表列：
+
+```text
+variant
+params
+future_mse
+long_mse
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+观测比例表：
+
+```text
+obs_ratio
+method
+future_mse
+long_mse
+relation_metrics
+```
+
+所有表格数据必须来自同一 `eval_forecasting` 协议。
+
+### 结果聚合
+
+建议新增或集成：
+
+```text
+eval/eval_forecasting.py --mode aggregate
+```
+
+输入：
+
+```text
+save/forecasting/interhuman/{run_name}/metrics_test.json
+```
+
+输出：
+
+```text
+results/forecasting/interhuman/tables/main_results.csv
+results/forecasting/interhuman/tables/main_results.md
+results/forecasting/interhuman/tables/ablation.csv
+results/forecasting/interhuman/tables/obs_ratio.csv
+```
+
+### P5 验收
+
+必须通过：
+
+```text
+所有主表结果至少 3 seed。
+所有实验记录 checkpoint、args、metrics。
+所有表格指标来自同一 evaluator。
+主表支持论文核心主张。
+ablation 支持 relation features 或 relation encoder 的必要性。
+失败或不稳定实验被记录。
+```
+
+### P5 失败回退
+
+```text
+主表不支持主张：回到 P4，不写成功结论。
+ablation 不支持主张：收缩贡献表述，或重新设计 relation module。
+观测比例不稳定：固定 20% 主协议，其他比例作为补充或限制。
+单 seed 波动大：增加 seed，不挑选有利结果。
+```
+
+### P5 阶段记录
+
+完成后新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p5-ablation-tables.md
+```
+
+记录：
+
+```text
+所有实验清单
+seed 列表
+checkpoint 和 args 路径
+表格数据源
+是否满足论文主张
+失败或不稳定实验
+是否允许进入 P6
+```
+
+## P6 设计：Visualization + Qualitative Analysis
+
+### 目标
+
+用定性结果解释 relation-aware 是否改善双人关系，而不是用可视化替代指标。
+
+### 新增文件
+
+```text
+sample/visualize_forecasting.py
+```
+
+也可以先把可视化逻辑放在 `eval/eval_forecasting.py --mode visualize`，但如果逻辑超过一个入口，应拆到 `sample/visualize_forecasting.py`。
+
+### 输入
+
+```text
+checkpoint paths
+test dataset
+normalizer
+selected sample ids
+```
+
+### 输出目录
+
+```text
+results/forecasting/interhuman/{run_name}/qualitative/{sample_id}/
+```
+
+每个样本保存：
+
+```text
+meta.json
+obs.npy
+gt.npy
+pred_repeat.npy
+pred_independent.npy
+pred_concat.npy
+pred_relation.npy
+distance_curve.png
+orientation_curve.png
+metrics_per_sample.json
+```
+
+可选：
+
+```text
+obs_h5_like.npy
+gt_h5_like.npy
+pred_relation_h5_like.npy
+rendered frames or videos
+```
+
+### 样本选择
+
+至少 8 个 test samples：
+
+```text
+2 个 relation-aware 明显优于 concat。
+2 个 relation-aware 与 concat 接近。
+2 个 relation-aware 失败或更差。
+2 个边界样本，覆盖较短 T>=150 和较长序列。
+```
+
+不得只保留成功样本。
+
+### 曲线
+
+必须输出：
+
+```text
+relative root distance over obs + future
+relative orientation error over future
+long-horizon segment error curve
+```
+
+曲线必须与 metrics 使用同一基础函数，避免图表和指标不一致。
+
+### P6 验收
+
+必须通过：
+
+```text
+至少 8 个样本输出完整。
+所有 pred 数值有限。
+obs / gt / pred 时间轴对齐。
+distance / orientation 曲线与 metrics 一致。
+失败样本被记录。
+render 卡住时仍有 npy + curves 可用于论文分析。
+```
+
+### P6 失败回退
+
+```text
+render 卡住：先输出 npy + 曲线图，不阻塞论文主指标。
+可视化显示动作崩坏但 MSE 低：回到 P4/P5 检查指标遗漏。
+样本挑选偏置：固定 selection rule，重新生成。
+```
+
+### P6 阶段记录
+
+完成后新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p6-qualitative-result.md
+```
+
+记录：
+
+```text
+样本列表
+输出路径
+成功案例
+失败案例
+图表说明
+是否支持 P5 结论
+```
+
+## 训练参数建议
+
+初始 smoke：
+
+```text
+batch_size=8
+num_steps=5
+max_samples=64
+hidden_dim=256
+num_layers=2
+lr=1e-3
+grad_accum_steps=1
+num_workers=0
+```
+
+中等训练：
+
+```text
+batch_size=32 或 64
+num_steps=5000-20000
+hidden_dim=256
+num_layers=2
+lr=1e-3 起，必要时 3e-4
+grad_accum_steps 按显存设置
+save_interval=1000
+eval_interval=1000
+```
+
+主实验：
+
+```text
+所有方法共享同一 batch_size、optimizer、num_steps、eval split、seed 列表。
+relation-aware 额外参数必须在 P5 中通过参数匹配消融解释。
+```
+
+## CLI 参数 contract
+
+`train/train_forecasting.py`：
+
+```text
+--dataset interhuman
+--data_path dataset/interhuman/smpl/conditioned
+--save_dir save/forecasting/interhuman/{run_name}
+--model_type independent|concat|relation
+--window_len 150
+--obs_len 30
+--pred_len 120
+--batch_size
+--num_steps
+--lr
+--weight_decay
+--hidden_dim
+--num_layers
+--relation_hidden_dim
+--grad_accum_steps
+--max_samples
+--seed
+--num_workers 0
+--save_interval
+--eval_interval
+--resume_checkpoint
+```
+
+`eval/eval_forecasting.py`：
+
+```text
+--mode dataset_smoke|metrics_sanity|repeat|checkpoint|aggregate
+--dataset interhuman
+--data_path dataset/interhuman/smpl/conditioned
+--split val|test
+--checkpoint
+--model_type repeat|independent|concat|relation
+--normalizer
+--save_dir
+--batch_size
+--num_workers 0
+```
+
+## 论文证据链
+
+论文主张成立需要同时满足：
+
+```text
+1. P2 证明 metrics 正确。
+2. P3 证明 trainable baselines 优于 repeat。
+3. P4 证明 relation-aware 优于 concat 的 long_mse 和至少一个 relation metric。
+4. P5 证明结果跨 seed 稳定，且 ablation 支持 relation module / features。
+5. P6 展示成功和失败案例，解释指标背后的行为。
+```
+
+不能使用的论证：
+
+```text
+只赢 repeat baseline。
+只赢 independent predictor。
+只在 future_mse 上微弱领先。
+只展示成功可视化。
+单 seed 结果直接写主结论。
+```
+
+## 风险与处理
+
+### 风险 1：确定性预测过难
+
+处理：
+
+```text
+第一阶段只声称 deterministic forecasting。
+多模态 future、best-of-K、diversity 放到 P7+。
+```
+
+### 风险 2：concat baseline 太强
+
+处理：
+
+```text
+承认 concat 能看到双人历史。
+把贡献表述为显式关系归纳偏置。
+用 parameter-matched ablation 支撑。
+```
+
+### 风险 3：rotation / translation 尺度不一致
+
+处理：
+
+```text
+训练用 normalizer。
+报告原始尺度指标。
+rotation_mse 和 translation_mse 分开报告。
+```
+
+### 风险 4：SMPL reproduction 与官方 SMPL-X 口径不同
+
+处理：
+
+```text
+论文中明确第一阶段是 SMPL reproduction protocol。
+不要声称完全对齐 InterHuman / InterGen 官方 SMPL-X 设置。
+```
+
+### 风险 5：可视化和指标冲突
+
+处理：
+
+```text
+如果可视化崩坏但 MSE 低，优先修指标和分析。
+不使用可视化掩盖主指标失败。
+```
+
+## 阶段记录模板
+
+每个阶段结束必须新建文档，包含：
+
+```text
+1. 引用的路线图和本设计文件。
+2. 实际实现文件。
+3. 是否偏离设计。
+4. 偏离原因。
+5. 验收命令。
+6. 验收结果。
+7. 输出路径。
+8. 是否允许进入下一阶段。
+```
+
+如果未达验收标准：
+
+```text
+不能写为完成。
+不能进入下一阶段做论文结论。
+只能写修复记录和继续修复实现。
+```
+
+## 最短执行路径
+
+建议后续实现顺序：
+
+```text
+1. P1 active vector + dataset + normalizer smoke
+2. P2 metrics sanity + repeat baseline
+3. P3 concat baseline smoke / train / eval
+4. P3 independent baseline smoke / train / eval
+5. P4 relation-aware smoke / train / eval
+6. P5 3-seed 主表
+7. P5 relation feature ablation
+8. P6 qualitative npy + curves
+9. P6 optional render
+```
+
+下一步只允许从 P1 开始。

--- a/docs/ai/context/20260603-185018-three-datasets-usage-review.md
+++ b/docs/ai/context/20260603-185018-three-datasets-usage-review.md
@@ -1,0 +1,298 @@
+# 三个数据集使用口径梳理
+
+## 问题
+
+用户问：
+
+```text
+这三个数据集分别怎么用？
+1. 在当前项目里怎么用？
+2. 论文 2403.11882v1.pdf 里怎么用？
+```
+
+这里的三个数据集指 ReGenNet 主线三套 action-reaction 数据：
+
+```text
+NTU RGB+D 120 / NTU120-AS
+Chi3D / Chi3D-AS
+InterHuman / InterHuman-AS
+```
+
+## 当前项目里的用法
+
+### 共同训练语义
+
+当前 ReGenNet 主路径是 action-reaction synthesis，不是 forecasting：
+
+```text
+actor motion -> generated reactor motion
+```
+
+代码路径：
+
+```text
+train/train_mdm.py
+  -> data_loaders/get_data.py
+  -> data_loaders/a2m/feeder.py 或 data_loaders/a2m/interhuman.py
+  -> data_loaders/tensors.py::ccollate
+  -> model/cmdm.py
+  -> diffusion/gaussian_diffusion.py
+```
+
+关键点：
+
+```text
+ccollate 把双人输入按 feature channel 拆成：
+cmotion = actor 条件
+motion  = reactor 训练目标
+```
+
+因此旧主路径学习的是“给定 actor 全段动作，生成 reactor 全段动作”。这和当前论文新方向的“前 30 帧双人动作 -> 后 120 帧双人动作”不是同一任务。
+
+### NTU120-AS
+
+本地数据：
+
+```text
+dataset/ntu120/smplx/conditioned/xsub.train.h5
+dataset/ntu120/smplx/conditioned/xsub.test.h5
+
+train: 4273
+test: 3845
+total: 8118
+shape: [T,56,6]
+```
+
+项目用途：
+
+```text
+dataset 参数：--dataset ntu
+loader：data_loaders/a2m/feeder.py::Feeder
+body_model：smplx
+num_frames：60
+num_actions：26
+训练目标：actor-conditioned reactor generation
+评估：eval/eval_cmdm.py 支持 ntu 分支
+recognition checkpoint：recognition_training/ntu_smplx/checkpoint_0100.pth.tar
+```
+
+可直接用来跑原论文式训练、采样、ST-GCN evaluator。也是当前三套数据里最接近原论文主实验主线的数据。
+
+### Chi3D-AS
+
+本地数据：
+
+```text
+dataset/chi3d/smplx/conditioned/chi3d_smplx_train.h5
+dataset/chi3d/smplx/conditioned/chi3d_smplx_test.h5
+
+train: 293
+test: 74
+total: 367
+shape: [T,56,6]
+```
+
+项目用途：
+
+```text
+dataset 参数：--dataset chi3d
+loader：data_loaders/a2m/feeder.py::Feeder
+body_model：smplx
+num_frames：150
+num_actions：8
+训练目标：actor-conditioned reactor generation
+评估：eval/eval_cmdm.py 支持 chi3d 分支
+recognition checkpoint：recognition_training/chi3d_smplx/checkpoint_0060.pth.tar
+```
+
+Chi3D 在项目里可以完整走原论文训练/评估路径，但样本小。论文写 373 条，本地处理后 H5 是 367 条，可能是预处理或过滤差异，需要复现论文时单独核对。
+
+### InterHuman-AS
+
+本地数据：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+
+train: 6021
+val: 580
+test: 1175
+union: 7776
+shape: [T,25,12]
+```
+
+项目用途：
+
+```text
+dataset 参数：--dataset interhuman
+loader：data_loaders/a2m/interhuman.py::InterHuman
+body_model：当前本地是 smpl
+num_frames：模型参数分支按 150
+num_actions：当前本地实现设为 1，即 interaction
+训练目标：actor-conditioned reactor generation smoke / baseline
+评估：eval/eval_cmdm.py 当前不支持 interhuman 分支
+recognition checkpoint：本地没有 InterHuman recognition checkpoint
+```
+
+InterHuman 是我们后来补的 H5 reproduction 路径，已经能训练 smoke 和 baseline，但还不能严格复现论文 Table 4。当前新的 forecasting 论文主线选择 InterHuman，是因为它更适合“固定 150 帧窗口、前 30 帧观测、预测后 120 帧”的任务。
+
+## 论文里的用法
+
+论文是：
+
+```text
+ReGenNet: Towards Human Action-Reaction Synthesis
+arXiv:2403.11882v1
+```
+
+论文任务不是未来预测，而是 action-reaction synthesis：
+
+```text
+given actor motion -> generate plausible reactor motion
+```
+
+作者把三套原始交互数据补上 actor-reactor order，形成：
+
+```text
+NTU120-AS
+Chi3D-AS
+InterHuman-AS
+```
+
+其中 `AS` 表示 asymmetry。
+
+### 论文中的 NTU120-AS
+
+论文说明：
+
+```text
+8118 human interaction sequences
+3 cameras
+26 action categories
+camera 1: main protocol
+cross-subject split
+camera 2: viewpoint generalization
+SMPL-X representation
+```
+
+用途：
+
+```text
+主实验数据集
+online / unconstrained action-reaction synthesis
+ablation 主数据集
+viewpoint generalization 数据集
+offline / constrained 扩展设置数据集
+```
+
+论文训练：
+
+```text
+batch_size=64
+frame_len=60
+500K steps
+DDIM-5 inference
+```
+
+### 论文中的 Chi3D-AS
+
+论文说明：
+
+```text
+8 action categories
+ground-truth SMPL-X parameters
+subtle hand gestures
+random train/test split 4:1
+frame_len=150
+```
+
+用途：
+
+```text
+验证 ReGenNet 在高质量 MoCap / SMPL-X 双人交互上的效果
+与 NTU120-AS 一起作为主要 comparison 数据集
+```
+
+论文训练：
+
+```text
+batch_size=16
+frame_len=150
+500K steps
+DDIM-5 inference
+```
+
+### 论文中的 InterHuman-AS
+
+论文说明：
+
+```text
+InterHuman 原始数据适合 action-reaction 设置
+但只包含 human body parameters，没有 dexterous hand movements
+Table 1 论文口径写 InterHuman-AS motions = 6022
+```
+
+用途：
+
+```text
+作为第三个 benchmark 数据集
+主要报告 online / unconstrained setting 的 Table 4
+评估指标是 FID / Acc. / Div. / Multimod.
+```
+
+注意：
+
+```text
+论文正文 4.1 写三套数据都用 SMPL-X body models，
+但 Table 1 又标 InterHuman modality 为 SMPL。
+本地当前 InterHuman H5 是 SMPL reproduction [T,25,12]，不是 NTU/Chi3D 的 SMPL-X [T,56,6]。
+```
+
+## 论文评估口径
+
+论文主要指标：
+
+```text
+FID
+action recognition accuracy
+diversity
+multi-modality
+```
+
+评估方式：
+
+```text
+训练 ST-GCN action recognition model。
+用 recognition feature 算 FID / diversity / multimodality。
+直接算 action recognition accuracy。
+root translation 会进入 recognition model，因为双人相对 root translation 对交互重要。
+每次生成 1000 samples，20 random seeds，报告 95% confidence interval。
+```
+
+## 当前项目与论文的差异
+
+```text
+NTU120-AS：当前项目最接近论文口径，数据、checkpoint、eval 分支都在。
+Chi3D-AS：当前项目也接近论文口径，但本地 H5 总数 367，不是论文写的 373。
+InterHuman-AS：当前项目能训练，但不是完整论文评估口径；缺 InterHuman recognition checkpoint，eval_cmdm 没有 interhuman 分支，本地表示是 SMPL 25-slot。
+```
+
+## 对当前 forecasting 主线的含义
+
+如果做 ReGenNet 原论文复现：
+
+```text
+优先 NTU120-AS 和 Chi3D-AS。
+InterHuman-AS 需要补 evaluator / checkpoint / 口径确认。
+```
+
+如果做当前新论文主线：
+
+```text
+优先 InterHuman。
+原因是样本最多、序列更长、交互语义更适合 150 帧窗口 forecasting。
+NTU120-AS 可作为后续 action-conditioned forecasting 扩展。
+Chi3D-AS 更适合作小规模泛化或 qualitative 补充。
+```

--- a/docs/ai/context/20260603-185530-ntu-chi3d-after-interhuman-plan.md
+++ b/docs/ai/context/20260603-185530-ntu-chi3d-after-interhuman-plan.md
@@ -1,0 +1,175 @@
+# InterHuman 第一阶段之后 NTU120-AS 与 Chi3D-AS 使用计划
+
+## 结论
+
+第一阶段只用 InterHuman。NTU120-AS 和 Chi3D-AS 不在第一阶段合并训练，也不作为 InterHuman 的验证集或测试集。
+
+后续推荐用途：
+
+```text
+NTU120-AS：第二阶段 action-conditioned forecasting / SMPL-X 对照 / 更规整大样本验证。
+Chi3D-AS：第三阶段小规模高质量 SMPL-X 泛化验证 / qualitative 补充。
+```
+
+## 为什么不合并
+
+三套数据的任务和表示不一致：
+
+```text
+InterHuman 当前本地表示: [T,25,12], SMPL, 无动作类别主标签。
+NTU120-AS 表示: [T,56,6], SMPL-X, 26 类动作。
+Chi3D-AS 表示: [T,56,6], SMPL-X, 8 类动作。
+```
+
+直接合并会引入额外问题：
+
+```text
+1. 需要统一 SMPL / SMPL-X 表示。
+2. 需要统一动作标签体系。
+3. 需要统一帧长协议，NTU 主口径 60 帧，InterHuman/Chi3D 更适合 150 帧。
+4. 需要统一 normalizer，否则 translation / rotation 尺度和采集域会混在一起。
+5. 需要重新定义 evaluator，不能再把跨数据集结果解释为单一数据集上的泛化能力。
+```
+
+因此合并训练不是当前论文主线的自然下一步，而是单独的 multi-dataset learning 研究问题。
+
+## 推荐阶段安排
+
+### P1-P6：InterHuman 主实验
+
+目标：
+
+```text
+证明 relation-aware joint forecasting 在 InterHuman 上优于 repeat / independent / concat。
+```
+
+使用：
+
+```text
+fixed window_len=150
+obs_len=30
+pred_len=120
+deterministic two-person forecasting
+MSE + relation metrics
+```
+
+产出：
+
+```text
+主结果表
+消融表
+定性分析
+```
+
+只有 InterHuman 主张成立后，才进入其他数据集。
+
+### P7：NTU120-AS 作为动作条件扩展
+
+用途 1：action-conditioned forecasting。
+
+设计：
+
+```text
+input: 前若干帧双人动作 + action label
+target: 后续双人动作
+dataset: NTU120-AS
+labels: 26 类双人动作
+representation: SMPL-X [T,56,6]
+```
+
+目的：
+
+```text
+验证 relation-aware predictor 是否能利用动作类别先验。
+```
+
+用途 2：规整大样本 SMPL-X 对照。
+
+设计：
+
+```text
+window_len=60 或 75
+obs_ratio=20%
+pred_ratio=80%
+```
+
+注意：
+
+```text
+NTU 平均帧长约 50-60，不能硬套 InterHuman 150 帧协议。
+应单独定义 NTU forecasting protocol。
+```
+
+### P8：Chi3D-AS 作为高质量小样本泛化验证
+
+用途：
+
+```text
+验证模型在高质量 MoCap / SMPL-X 双人交互上的表现。
+```
+
+推荐方式：
+
+```text
+1. 不把 Chi3D 当主数据集。
+2. 用 InterHuman 学到的设计思想，在 Chi3D 上重新训练小模型。
+3. 或把 Chi3D 作为 cross-dataset qualitative / low-data adaptation。
+```
+
+注意：
+
+```text
+Chi3D 样本只有约 293 train / 74 test，本地 H5 总数 367。
+结果波动会大，不适合单独支撑主论文结论。
+```
+
+### P9：统一多数据集训练，可选
+
+只有在 P7/P8 都稳定后才考虑。
+
+前置条件：
+
+```text
+1. 统一表示到 SMPL-X 或统一 active vector schema。
+2. 分别保留 dataset-specific normalizer 或使用 domain embedding。
+3. 明确 multi-dataset split，禁止样本泄漏。
+4. evaluator 改成 dataset-aware。
+5. 论文问题改为 multi-domain two-person forecasting。
+```
+
+这不是第一篇论文的必要项。
+
+## 推荐论文写法
+
+第一篇论文：
+
+```text
+主数据集：InterHuman
+扩展实验：可暂不做 NTU/Chi3D
+```
+
+如果时间允许，补充实验可以写：
+
+```text
+NTU120-AS：action-conditioned short-window forecasting
+Chi3D-AS：small-scale SMPL-X qualitative/generalization
+```
+
+但不能把 NTU/Chi3D 的缺失作为阻塞 InterHuman P1-P6 的理由。
+
+## 当前下一步
+
+继续执行：
+
+```text
+P1 InterHuman forecasting dataset + normalizer
+```
+
+不要提前实现：
+
+```text
+NTU forecasting loader
+Chi3D forecasting loader
+multi-dataset normalizer
+unified SMPL/SMPL-X conversion
+```

--- a/docs/ai/context/20260603-190003-forecasting-final-official-design.md
+++ b/docs/ai/context/20260603-190003-forecasting-final-official-design.md
@@ -1,0 +1,1026 @@
+# 交互感知双人动作联合预测最终正式设计文档
+
+## 文档定位
+
+本文件是当前项目第一篇论文工程实现的最终正式设计文档。后续实现、验收、阶段记录和论文结果解释均以本文件为准。
+
+本文件整合并收敛以下文档：
+
+```text
+docs/ai/context/20260603-184214-forecasting-p1-p6-complete-design.md
+docs/ai/context/20260603-185018-three-datasets-usage-review.md
+docs/ai/context/20260603-185530-ntu-chi3d-after-interhuman-plan.md
+```
+
+本文件不覆盖历史文档。历史文档用于追溯讨论过程；本文件用于执行。
+
+## 最终研究目标
+
+英文题目：
+
+```text
+Interaction-aware joint forecasting of two-person human motion from partial observations.
+```
+
+中文题目：
+
+```text
+基于部分观测的交互感知双人动作联合未来预测。
+```
+
+核心问题：
+
+```text
+给定一段双人交互动作的前 20% 观测，联合预测两个人后续 80% 的未来动作。
+```
+
+第一篇论文只验证一个清晰主张：
+
+```text
+双人未来动作预测不是两个单人未来预测的简单拼接。
+显式建模两人关系应改善长期预测误差和交互关系一致性。
+```
+
+该主张必须可证伪：
+
+```text
+如果 relation-aware model 不能稳定优于 concat no-relation baseline，
+尤其不能改善 long-horizon error 和至少一个 relation metric，
+则不能声称交互感知建模有效。
+```
+
+## 数据集最终决策
+
+### 第一阶段主数据集
+
+第一阶段只使用：
+
+```text
+InterHuman
+```
+
+固定协议：
+
+```text
+source: dataset/interhuman/smpl/conditioned/interhuman_{train,val,test}.h5
+representation: SMPL reproduction active vector
+window_len: 150
+obs_len: 30
+pred_len: 120
+input: 前 30 帧双人动作
+target: 后 120 帧双人动作
+task: deterministic two-person forecasting
+```
+
+### 不合并三套数据集
+
+以下三套数据集不是 train / val / test：
+
+```text
+NTU120-AS
+Chi3D-AS
+InterHuman-AS
+```
+
+它们是 ReGenNet 论文中的三个独立 benchmark 数据域。第一阶段不做：
+
+```text
+把 NTU120-AS、Chi3D-AS、InterHuman-AS 合并训练。
+把 NTU120-AS 当 train、Chi3D-AS 当 val、InterHuman-AS 当 test。
+把 NTU/Chi3D 作为 InterHuman P1-P6 的阻塞项。
+```
+
+原因：
+
+```text
+InterHuman 当前本地表示: [T,25,12], SMPL, 无动作类别主标签。
+NTU120-AS 表示: [T,56,6], SMPL-X, 26 类动作。
+Chi3D-AS 表示: [T,56,6], SMPL-X, 8 类动作。
+三者帧长、动作标签、normalizer、evaluator 和人体模型表示均不一致。
+```
+
+直接合并会把当前问题改成 multi-domain forecasting，不是第一篇论文需要解决的问题。
+
+### 后续扩展数据集
+
+InterHuman P1-P6 成立后，后续阶段再考虑：
+
+```text
+P7: NTU120-AS action-conditioned forecasting / SMPL-X 大样本对照。
+P8: Chi3D-AS 高质量小样本 SMPL-X 泛化验证或 qualitative 补充。
+P9: 统一多数据集训练，作为单独研究问题。
+```
+
+## 本地数据事实
+
+### InterHuman
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+```
+
+格式：
+
+```text
+shape: [T,25,12]
+body_model: smpl
+rotation: rot6d
+translation_slot: 24
+translation_origin: actor frame 0
+```
+
+样本数：
+
+```text
+train: total 6021, T>=150 2910
+val:   total 580,  T>=150 226
+test:  total 1175, T>=150 508
+```
+
+### NTU120-AS
+
+```text
+dataset/ntu120/smplx/conditioned/xsub.train.h5
+dataset/ntu120/smplx/conditioned/xsub.test.h5
+
+train: 4273
+test: 3845
+total: 8118
+shape: [T,56,6]
+recognition checkpoint: recognition_training/ntu_smplx/checkpoint_0100.pth.tar
+```
+
+### Chi3D-AS
+
+```text
+dataset/chi3d/smplx/conditioned/chi3d_smplx_train.h5
+dataset/chi3d/smplx/conditioned/chi3d_smplx_test.h5
+
+train: 293
+test: 74
+total: 367
+shape: [T,56,6]
+recognition checkpoint: recognition_training/chi3d_smplx/checkpoint_0060.pth.tar
+```
+
+### InterHuman 与 ReGenNet 原论文的差异
+
+当前本地 InterHuman 是 SMPL reproduction H5：
+
+```text
+[T,25,12]
+```
+
+NTU/Chi3D 是 SMPL-X：
+
+```text
+[T,56,6]
+```
+
+当前本地没有：
+
+```text
+InterHuman text/caption 目录
+InterHuman recognition checkpoint
+eval_cmdm.py 的 interhuman evaluator 分支
+```
+
+因此第一篇 forecasting 论文不依赖 ReGenNet Table 4 的 ST-GCN evaluator，不追 InterHuman-AS Table 4 复现。
+
+## 当前项目旧路径与新路径的关系
+
+### 旧 ReGenNet 路径
+
+旧路径任务：
+
+```text
+actor 全段动作 -> generated reactor 全段动作
+```
+
+旧路径代码：
+
+```text
+train/train_mdm.py
+data_loaders/get_data.py
+data_loaders/a2m/feeder.py
+data_loaders/a2m/interhuman.py
+data_loaders/tensors.py::ccollate
+model/cmdm.py
+diffusion/gaussian_diffusion.py
+eval/eval_cmdm.py
+sample/cgenerate.py
+```
+
+关键语义：
+
+```text
+ccollate 将双人数据按 channel 拆为 actor 条件 cmotion 和 reactor 目标 motion。
+```
+
+### 新 forecasting 路径
+
+新路径任务：
+
+```text
+双人前缀观测 -> 双人未来预测
+```
+
+新路径不复用 `ccollate`，不改 diffusion 主路径。
+
+第一阶段不得修改：
+
+```text
+train/train_mdm.py
+model/cmdm.py
+diffusion/gaussian_diffusion.py
+eval/eval_cmdm.py
+```
+
+除非后续单独写扩展文档并说明为何需要接入旧 ReGenNet 路径。
+
+## 第一阶段协议
+
+固定窗口：
+
+```text
+window_len = 150
+obs_len = 30
+pred_len = 120
+```
+
+长度规则：
+
+```text
+T >= 150: 使用
+T < 150: 过滤
+```
+
+不得 padding：
+
+```text
+padding 会伪造未来动作，破坏 forecasting 任务定义。
+```
+
+训练采样：
+
+```text
+train: random crop 150 frames
+val/test: center crop 150 frames
+```
+
+归一化：
+
+```text
+使用 train split 统计 normalizer。
+训练 loss 在 normalized space。
+所有论文指标在 original scale。
+```
+
+## 数据表示 contract
+
+### H5 原始表示
+
+```text
+motion: [T,25,12]
+
+actor_rot6d:         motion[:, :24, 0:6]
+actor_translation:   motion[:, 24, 0:3]
+reactor_rot6d:       motion[:, :24, 6:12]
+reactor_translation: motion[:, 24, 6:9]
+```
+
+### Active vector
+
+```text
+person_dim = 24 * 6 + 3 = 147
+two_person_dim = 2 * 147 = 294
+motion_active: [T,2,147]
+```
+
+映射：
+
+```text
+motion_active[:, 0, :144] = actor_rot6d.reshape(T, 144)
+motion_active[:, 0, 144:147] = actor_translation
+motion_active[:, 1, :144] = reactor_rot6d.reshape(T, 144)
+motion_active[:, 1, 144:147] = reactor_translation
+```
+
+窗口：
+
+```text
+obs:    [30,2,147]
+target: [120,2,147]
+```
+
+### Restore
+
+active vector 必须能还原为 H5-like motion：
+
+```text
+active [T,2,147] -> motion [T,25,12]
+```
+
+用途：
+
+```text
+可视化
+rot2xyz 输入
+后续 qualitative analysis
+```
+
+## Normalizer contract
+
+统计来源：
+
+```text
+split: train only
+samples: T>=150 train sequences
+frames: 每条可用序列的全部帧
+space: active vector original scale
+```
+
+形状：
+
+```text
+mean: [1,1,2,147]
+std:  [1,1,2,147]
+eps: 1e-6
+```
+
+防护：
+
+```text
+std < eps 的维度设为 1.0
+```
+
+保存：
+
+```text
+normalizer.pt
+normalizer.json
+```
+
+`normalizer.json` 至少记录：
+
+```text
+dataset
+data_path
+window_len
+obs_len
+pred_len
+num_train_sequences_used
+num_train_frames_used
+person_dim
+eps
+created_at
+```
+
+## Metrics contract
+
+输入：
+
+```text
+pred:   Tensor[B,120,2,147]
+target: Tensor[B,120,2,147]
+obs:    Tensor[B,30,2,147]
+```
+
+要求：
+
+```text
+pred / target / obs 均为 original scale。
+metrics key 固定，所有模型共用同一 evaluator。
+```
+
+必须输出：
+
+```text
+future_mse
+rotation_mse
+translation_mse
+short_mse
+mid_mse
+long_mse
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+定义：
+
+```text
+future_mse = mean((pred - target)^2)
+rotation_mse = mean((pred[..., :144] - target[..., :144])^2)
+translation_mse = mean((pred[..., 144:147] - target[..., 144:147])^2)
+short_mse = future_mse over frames 0:40
+mid_mse = future_mse over frames 40:80
+long_mse = future_mse over frames 80:120
+```
+
+相对 root distance：
+
+```text
+dist = norm(trans_A - trans_B)
+relative_root_distance_error = mean(abs(pred_dist - target_dist))
+```
+
+相对朝向：
+
+```text
+root rot6d -> rotation_6d_to_matrix
+R_rel = R_A^T R_B
+angle = acos(clamp((trace(R_err) - 1) / 2))
+relative_orientation_error = mean(angle)
+```
+
+必须 clamp：
+
+```text
+acos 输入必须 clamp 到 [-1 + eps, 1 - eps]，避免 NaN。
+```
+
+inter-person distance consistency：
+
+```text
+使用 obs 最后一帧和 future frames 的 root distance delta。
+报告 root distance trend consistency，不声称覆盖完整 interaction quality。
+```
+
+## 新增文件设计
+
+第一阶段新增：
+
+```text
+data_loaders/forecasting/__init__.py
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+utils/forecasting_motion.py
+utils/forecasting_metrics.py
+model/forecasting.py
+train/train_forecasting.py
+eval/eval_forecasting.py
+sample/visualize_forecasting.py
+```
+
+职责：
+
+```text
+data_loaders/forecasting/interhuman.py
+  InterHuman H5 读取、T>=150 过滤、random/center crop、dataset item。
+
+data_loaders/forecasting/tensors.py
+  forecasting_collate，不做 padding。
+
+utils/forecasting_motion.py
+  active vector extract/restore、normalizer、relation feature 基础函数。
+
+utils/forecasting_metrics.py
+  original scale metrics。
+
+model/forecasting.py
+  repeat helper、independent、concat、relation-aware predictor。
+
+train/train_forecasting.py
+  supervised training loop、checkpoint、args、normalizer、val/test eval。
+
+eval/eval_forecasting.py
+  dataset smoke、metrics sanity、repeat baseline、checkpoint evaluation、aggregate。
+
+sample/visualize_forecasting.py
+  npy、曲线图、可选 render。
+```
+
+## P1：Dataset + Normalizer
+
+目标：
+
+```text
+建立 InterHuman forecasting 数据协议，让后续所有 baseline 和模型读取完全一致的 obs / target。
+```
+
+输出 item：
+
+```text
+{
+  "obs": Tensor[30,2,147],
+  "target": Tensor[120,2,147],
+  "sample_id": str,
+  "start": int,
+  "length": int,
+}
+```
+
+batch：
+
+```text
+obs: Tensor[B,30,2,147]
+target: Tensor[B,120,2,147]
+meta: list[dict]
+```
+
+验收：
+
+```text
+train dataset length = 2910
+val dataset length = 226
+test dataset length = 508
+obs shape = [30,2,147]
+target shape = [120,2,147]
+所有 obs/target 有限
+train 同一样本多次读取 start 可变化
+val/test 同一样本多次读取 start 固定
+normalizer 可保存和加载
+normalize -> denormalize 误差在浮点容忍范围
+active -> h5-like -> active 误差在浮点容忍范围
+```
+
+## P2：Metrics + Repeat Baseline
+
+目标：
+
+```text
+在训练模型前完成评估闭环。
+```
+
+repeat baseline：
+
+```text
+pred[:, t] = obs[:, -1]
+```
+
+验收：
+
+```text
+pred == target 时所有 MSE 类指标为 0。
+pred == target 时 relative_root_distance_error 为 0。
+pred == target 时 relative_orientation_error 接近 0。
+repeat baseline 可完整评估 test split。
+metrics 文件保存为 json/yaml。
+所有指标 key 固定。
+```
+
+P2 不过，不进入 P3。
+
+## P3：Independent / Concat Baselines
+
+目标：
+
+```text
+建立两个可训练 baseline，防止 relation-aware 只赢 repeat baseline。
+```
+
+### Independent Predictor
+
+定义：
+
+```text
+A_obs -> A_future
+B_obs -> B_future
+concat(A_future, B_future)
+```
+
+硬约束：
+
+```text
+A 分支不能读 B_obs。
+B 分支不能读 A_obs。
+```
+
+### Concat No-Relation Predictor
+
+定义：
+
+```text
+concat(A_obs, B_obs) -> future(A,B)
+```
+
+约束：
+
+```text
+可以看到双人原始历史。
+不能显式构造 relation features。
+不能使用 relation_encoder。
+```
+
+论文表述：
+
+```text
+concat 不是没有关系信息，而是没有显式关系归纳偏置。
+```
+
+训练：
+
+```text
+loss = normalized active-vector MSE
+optimizer = AdamW
+num_steps = optimizer steps
+支持 grad_accum_steps
+num_workers 默认 0
+```
+
+验收：
+
+```text
+independent smoke 通过。
+concat smoke 通过。
+两个模型 checkpoint 可保存和加载。
+两个模型都能输出 P2 固定 metrics。
+两个模型至少优于 repeat baseline 的 future_mse。
+记录参数量、训练预算、seed。
+```
+
+P3 不过，不进入 P4。
+
+## P4：Relation-Aware Joint Predictor
+
+目标：
+
+```text
+实现论文核心模型：显式关系推理 + 双人联合未来预测。
+```
+
+关系特征：
+
+```text
+relative root translation: trans_A - trans_B
+relative root velocity: velocity_A - velocity_B
+root distance: ||trans_A - trans_B||
+relative root orientation: R_A^T R_B
+```
+
+第一版结构：
+
+```text
+person_encoder(A_obs) -> h_A
+person_encoder(B_obs) -> h_B
+relation_encoder(relation_features) -> h_rel
+fuse(h_A, h_B, h_rel) -> joint_decoder -> future(A,B)
+```
+
+推荐：
+
+```text
+person_encoder: shared GRU
+relation_encoder: GRU
+fusion: concat + MLP
+decoder: MLP direct prediction
+```
+
+第一版不使用 graph network。
+
+主 loss：
+
+```text
+normalized active-vector MSE
+```
+
+可选 ablation：
+
+```text
++ relative_root_distance_loss
++ relative_orientation_loss
+```
+
+验收：
+
+```text
+relation-aware smoke 通过。
+checkpoint 可加载。
+test metrics 完整输出。
+future_mse 不差于 concat。
+long_mse 优于 concat。
+至少一个 relation metric 优于 concat。
+记录 relation features、参数量、训练预算、seed。
+```
+
+论文主张最低门槛：
+
+```text
+long_mse 和至少一个 relation metric 明显优于 concat no-relation。
+```
+
+如果只赢 independent，不赢 concat，论文核心贡献不成立。
+
+## P5：Ablation + Paper Tables
+
+目标：
+
+```text
+证明 relation-aware 不是偶然变好，生成论文可用主表和消融表。
+```
+
+主实验：
+
+```text
+Repeat
+Independent
+Concat no-relation
+Relation-aware
+```
+
+重复实验：
+
+```text
+至少 3 seeds: 0, 1, 2
+报告 mean/std 或 mean±std
+```
+
+必做消融：
+
+```text
+concat no-relation
+relation-aware without relation encoder
+relation-aware with relation encoder
+parameter-matched concat
+relative translation only
+relative velocity only
+relative orientation only
+all relation features
+```
+
+观测比例补充：
+
+```text
+10%: obs=15, pred=135
+20%: obs=30, pred=120
+30%: obs=45, pred=105
+50%: obs=75, pred=75
+```
+
+主表仍以 20% 为主协议。
+
+主结果表列：
+
+```text
+method
+params
+future_mse
+rotation_mse
+translation_mse
+long_mse
+relative_root_distance_error
+relative_orientation_error
+inter_person_distance_consistency
+```
+
+验收：
+
+```text
+所有主表结果至少 3 seed。
+所有实验记录 checkpoint、args、metrics。
+所有表格指标来自同一 evaluator。
+主表支持论文核心主张。
+ablation 支持 relation module / relation features。
+失败或不稳定实验被记录。
+```
+
+P5 不支持主张时，不写成功结论，回到 P4。
+
+## P6：Visualization + Qualitative Analysis
+
+目标：
+
+```text
+用定性结果解释模型如何改善或未改善双人关系。
+```
+
+输出：
+
+```text
+results/forecasting/interhuman/{run_name}/qualitative/{sample_id}/
+```
+
+每个样本保存：
+
+```text
+meta.json
+obs.npy
+gt.npy
+pred_repeat.npy
+pred_independent.npy
+pred_concat.npy
+pred_relation.npy
+distance_curve.png
+orientation_curve.png
+metrics_per_sample.json
+```
+
+样本选择：
+
+```text
+至少 8 个 test samples。
+包含 relation-aware 明显优于 concat 的样本。
+包含 relation-aware 与 concat 接近的样本。
+包含 relation-aware 失败或更差的样本。
+包含短序列边界和长序列样本。
+```
+
+验收：
+
+```text
+所有 pred 数值有限。
+obs / gt / pred 时间轴对齐。
+曲线与 metrics 使用同一基础函数。
+失败样本被记录。
+render 卡住时仍保留 npy + curves。
+```
+
+P6 不能替代 P5 主指标。
+
+## CLI contract
+
+训练入口：
+
+```text
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m train.train_forecasting \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --save_dir save/forecasting/interhuman/{run_name} \
+  --model_type independent|concat|relation \
+  --window_len 150 \
+  --obs_len 30 \
+  --pred_len 120 \
+  --batch_size N \
+  --num_steps N \
+  --hidden_dim N \
+  --num_layers N \
+  --lr LR \
+  --grad_accum_steps N \
+  --max_samples -1 \
+  --num_workers 0 \
+  --seed N
+```
+
+评估入口：
+
+```text
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m eval.eval_forecasting \
+  --mode dataset_smoke|metrics_sanity|repeat|checkpoint|aggregate \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --split val|test \
+  --batch_size N \
+  --num_workers 0 \
+  --save_dir save/forecasting/interhuman/{run_name}
+```
+
+必须使用 `regennet` micromamba 环境。裸 `python3` 不作为验收命令。
+
+## 保存 contract
+
+每个训练 run 保存：
+
+```text
+args.json
+normalizer.pt
+normalizer.json
+model{step:09}.pt
+opt{step:09}.pt
+metrics_val.json
+metrics_val.yaml
+metrics_test.json
+metrics_test.yaml
+```
+
+每个 run 必须记录：
+
+```text
+model_type
+num_params
+seed
+effective_batch_size
+num_steps
+data_path
+window_len / obs_len / pred_len
+```
+
+## 论文证据链
+
+论文成立需要同时满足：
+
+```text
+1. P1 证明数据协议正确。
+2. P2 证明 metrics 正确。
+3. P3 证明 trainable baselines 优于 repeat。
+4. P4 证明 relation-aware 优于 concat 的 long_mse 和至少一个 relation metric。
+5. P5 证明结果跨 seed 稳定，且消融支持 relation module / features。
+6. P6 展示成功和失败案例，解释指标背后的行为。
+```
+
+不能使用的论证：
+
+```text
+只赢 repeat baseline。
+只赢 independent predictor。
+只在 future_mse 上微弱领先。
+只展示成功可视化。
+单 seed 结果直接写主结论。
+```
+
+## 风险与处理
+
+### 确定性预测过难
+
+处理：
+
+```text
+第一篇论文只声称 deterministic forecasting。
+best-of-K、diversity、多模态未来放到后续扩展。
+```
+
+### Concat baseline 太强
+
+处理：
+
+```text
+承认 concat 能看到双人历史。
+把贡献定义为显式关系归纳偏置。
+做 parameter-matched ablation。
+```
+
+### SMPL / SMPL-X 口径不一致
+
+处理：
+
+```text
+第一阶段明确为 InterHuman SMPL reproduction protocol。
+不声称完全对齐 ReGenNet 官方 SMPL-X 设置。
+NTU/Chi3D 的 SMPL-X 对照放到 P7/P8。
+```
+
+### 可视化和指标冲突
+
+处理：
+
+```text
+如果可视化崩坏但 MSE 低，优先检查 metrics。
+不使用可视化掩盖主指标失败。
+```
+
+## 阶段记录要求
+
+每个阶段完成后必须新建：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p{N}-*.md
+```
+
+记录：
+
+```text
+1. 引用本最终设计文档。
+2. 实际实现文件。
+3. 是否偏离设计。
+4. 偏离原因。
+5. 验收命令。
+6. 验收结果。
+7. 输出路径。
+8. 是否允许进入下一阶段。
+```
+
+如果未达验收标准：
+
+```text
+不能写为完成。
+不能进入下一阶段做论文结论。
+只能写修复记录并继续修复。
+```
+
+## 最终执行顺序
+
+只允许按以下顺序推进：
+
+```text
+1. P1 InterHuman dataset + active vector + normalizer smoke
+2. P2 metrics sanity + repeat baseline
+3. P3 concat baseline smoke / train / eval
+4. P3 independent baseline smoke / train / eval
+5. P4 relation-aware smoke / train / eval
+6. P5 3-seed main table
+7. P5 relation feature ablation
+8. P6 qualitative npy + curves
+9. P6 optional render
+10. P7 NTU120-AS 扩展
+11. P8 Chi3D-AS 扩展
+```
+
+当前下一步：
+
+```text
+开始 P1。
+```
+
+不得提前实现：
+
+```text
+relation-aware model
+NTU forecasting loader
+Chi3D forecasting loader
+multi-dataset normalizer
+SMPL/SMPL-X 统一转换
+diffusion forecasting
+```

--- a/docs/ai/context/20260603-190529-forecasting-p1-plan.md
+++ b/docs/ai/context/20260603-190529-forecasting-p1-plan.md
@@ -1,0 +1,440 @@
+# Forecasting P1 计划文档
+
+## 文档定位
+
+本文使用 `using-superpowers` 工作流生成，是以下正式设计的 P1 落地计划：
+
+```text
+docs/ai/context/20260603-190003-forecasting-final-official-design.md
+```
+
+补充参考：
+
+```text
+docs/ai/context/20260603-184214-forecasting-p1-p6-complete-design.md
+docs/ai/context/20260603-161334-forecasting-p1-p2-design.md
+```
+
+本文只规划 P1，不进入实现结果记录。P1 完成后必须新建结果文档：
+
+```text
+docs/ai/context/YYYYMMDD-HHMMSS-forecasting-p1-dataset-result.md
+```
+
+## P1 目标
+
+建立 InterHuman forecasting 的唯一数据协议，让后续 repeat、independent、concat 和 relation-aware 模型读取完全一致的 `obs / target`。
+
+P1 必须交付：
+
+```text
+InterHumanForecastDataset
+forecasting_collate
+active vector extract / restore
+train-only normalizer
+dataset_smoke 验收入口
+```
+
+P1 通过后才允许进入 P2 metrics + repeat baseline。
+
+## 必须解决的问题
+
+从第一性原理看，P1 只解决四件事：
+
+```text
+1. 从 H5 原始 [T,25,12] 中抽取真实监督维度，避免 zero channel 污染 loss / metrics。
+2. 把固定 150 帧窗口切成 30 帧观测和 120 帧未来目标。
+3. 只用 train split 统计 normalizer，训练使用 normalized space，论文指标保留 original scale。
+4. 用可重复的 smoke 命令证明 shape、样本数、finite、normalizer 和 roundtrip 都正确。
+```
+
+## 非目标
+
+P1 不做：
+
+```text
+P2 metrics
+repeat baseline
+independent / concat / relation-aware model
+训练循环
+可视化
+diffusion forecasting
+ReGenNet Table 4 evaluator
+NTU120-AS / Chi3D-AS 接入
+padding
+multi-window eval
+window recenter
+```
+
+P1 不修改旧 ReGenNet 主路径：
+
+```text
+train/train_mdm.py
+model/cmdm.py
+diffusion/gaussian_diffusion.py
+eval/eval_cmdm.py
+data_loaders/tensors.py::ccollate
+```
+
+原因是旧路径语义是 `actor condition -> reactor target`，新任务语义是 `observed prefix -> future suffix`。
+
+## 输入协议
+
+数据源：
+
+```text
+dataset/interhuman/smpl/conditioned/interhuman_train.h5
+dataset/interhuman/smpl/conditioned/interhuman_val.h5
+dataset/interhuman/smpl/conditioned/interhuman_test.h5
+dataset/interhuman/smpl/conditioned/meta.json
+```
+
+H5 单条样本：
+
+```text
+motion: [T,25,12]
+actor_rot6d:         motion[:, :24, 0:6]
+actor_translation:   motion[:, 24, 0:3]
+reactor_rot6d:       motion[:, :24, 6:12]
+reactor_translation: motion[:, 24, 6:9]
+```
+
+固定 forecasting 协议：
+
+```text
+window_len = 150
+obs_len = 30
+pred_len = 120
+T >= 150: 使用
+T < 150: 过滤
+train: random crop
+val/test: center crop
+```
+
+预期可用样本数：
+
+```text
+train: 2910
+val:   226
+test:  508
+```
+
+## Active Vector 计划
+
+新增文件：
+
+```text
+utils/forecasting_motion.py
+```
+
+常量：
+
+```text
+NUM_PERSONS = 2
+NUM_BODY_JOINTS = 24
+ROT6D_DIM = 6
+ROT_DIM = 144
+TRANSL_DIM = 3
+PERSON_DIM = 147
+```
+
+接口：
+
+```text
+extract_active_motion(motion_h5) -> active
+restore_active_motion(active) -> motion_h5_like
+```
+
+形状：
+
+```text
+motion_h5: [T,25,12]
+active:    [T,2,147]
+```
+
+映射：
+
+```text
+active[:, 0, :144] = motion[:, :24, 0:6].reshape(T, 144)
+active[:, 0, 144:147] = motion[:, 24, 0:3]
+active[:, 1, :144] = motion[:, :24, 6:12].reshape(T, 144)
+active[:, 1, 144:147] = motion[:, 24, 6:9]
+```
+
+restore 时只还原有效 channel，其他 channel 保持 0。P1 必须验证：
+
+```text
+active -> h5-like -> active 最大误差在浮点容忍范围内
+```
+
+实现约束：
+
+```text
+优先支持 torch.Tensor。
+保持 dtype / device。
+输入 shape 不合法时直接 ValueError。
+不做坐标重中心化。
+```
+
+## Dataset 计划
+
+新增文件：
+
+```text
+data_loaders/forecasting/__init__.py
+data_loaders/forecasting/interhuman.py
+```
+
+核心类：
+
+```text
+InterHumanForecastDataset(
+    data_path,
+    split,
+    window_len=150,
+    obs_len=30,
+    pred_len=120,
+    max_samples=-1,
+    seed=0,
+)
+```
+
+split 只读取自己的 H5 文件，不复用旧 `InterHuman` loader 的 train/eval 合并索引。
+
+输出 item：
+
+```text
+{
+  "obs": Tensor[30,2,147],
+  "target": Tensor[120,2,147],
+  "sample_id": str,
+  "start": int,
+  "length": int,
+}
+```
+
+采样规则：
+
+```text
+train:
+  start 随机取 [0, T - 150]
+  同一样本多次读取 start 应可变化
+
+val/test:
+  start = floor((T - 150) / 2)
+  同一样本多次读取 start 必须固定
+```
+
+H5 句柄规则：
+
+```text
+惰性打开 h5py.File。
+__getstate__ 中清空句柄，避免 DataLoader worker 复用不可 pickle 的 H5 handle。
+```
+
+`max_samples` 规则：
+
+```text
+先按 T>=150 过滤，再截断 max_samples。
+```
+
+## Collate 计划
+
+新增文件：
+
+```text
+data_loaders/forecasting/tensors.py
+```
+
+接口：
+
+```text
+forecasting_collate(batch) -> obs, target, meta
+```
+
+输出：
+
+```text
+obs:    Tensor[B,30,2,147]
+target: Tensor[B,120,2,147]
+meta:   list[dict]
+```
+
+不做 padding。因为 P1 固定窗口，batch 内 shape 必须一致。
+
+## Normalizer 计划
+
+新增在：
+
+```text
+utils/forecasting_motion.py
+```
+
+接口：
+
+```text
+ForecastingNormalizer(mean, std, eps=1e-6)
+compute_forecasting_normalizer(data_path, save_dir, window_len=150, obs_len=30, pred_len=120, eps=1e-6)
+load_forecasting_normalizer(path)
+```
+
+统计来源：
+
+```text
+split: train only
+samples: T>=150 train sequences
+frames: 每条可用序列的全部帧
+space: active vector original scale
+```
+
+统计方式：
+
+```text
+使用 streaming sum / sum_sq，避免把所有 train frame 堆到内存。
+sum 和 sum_sq 使用 float64 CPU tensor。
+std < eps 的维度设为 1.0。
+```
+
+保存：
+
+```text
+normalizer.pt
+normalizer.json
+```
+
+张量形状：
+
+```text
+mean: [1,1,2,147]
+std:  [1,1,2,147]
+```
+
+`normalizer.json` 至少包含：
+
+```text
+dataset
+data_path
+window_len
+obs_len
+pred_len
+num_train_sequences_used
+num_train_frames_used
+person_dim
+eps
+created_at
+```
+
+P1 必须验证：
+
+```text
+normalizer 可保存和加载
+normalize -> denormalize 最大误差在浮点容忍范围内
+```
+
+## Smoke 入口计划
+
+正式设计的 P1 验收命令依赖：
+
+```text
+python -m eval.eval_forecasting --mode dataset_smoke
+```
+
+因此 P1 允许新增：
+
+```text
+eval/eval_forecasting.py
+```
+
+但 P1 只实现 `dataset_smoke`，不实现 metrics、repeat 或 checkpoint evaluation。P2 再扩展同一入口。
+
+默认输出目录：
+
+```text
+save/forecasting/interhuman/p1_dataset_smoke
+```
+
+验收命令：
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m eval.eval_forecasting \
+  --mode dataset_smoke \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --window_len 150 \
+  --obs_len 30 \
+  --pred_len 120 \
+  --batch_size 4 \
+  --num_workers 0 \
+  --save_dir save/forecasting/interhuman/p1_dataset_smoke
+```
+
+`dataset_smoke` 检查项：
+
+```text
+train dataset length = 2910
+val dataset length = 226
+test dataset length = 508
+obs shape = [30,2,147]
+target shape = [120,2,147]
+batch obs shape = [B,30,2,147]
+batch target shape = [B,120,2,147]
+所有 obs/target finite
+train 同一样本多次读取 start 可变化
+val/test 同一样本多次读取 start 固定
+normalizer.pt 和 normalizer.json 可写出
+normalizer 可加载
+normalize -> denormalize 误差在容忍范围内
+active -> h5-like -> active 误差在容忍范围内
+```
+
+容忍范围：
+
+```text
+float32 roundtrip max_abs_error <= 1e-5
+relative_orientation / metrics 不在 P1 检查
+```
+
+## 实现顺序
+
+1. 新建 `data_loaders/forecasting/`，补 `__init__.py`。
+2. 实现 `utils/forecasting_motion.py` 的 active vector extract / restore。
+3. 实现 `InterHumanForecastDataset` 的 H5 path 解析、长度过滤、crop 和 item 输出。
+4. 实现 `forecasting_collate`。
+5. 实现 `ForecastingNormalizer`、streaming normalizer 统计、保存和加载。
+6. 新增 `eval/eval_forecasting.py --mode dataset_smoke`。
+7. 运行 P1 smoke 命令。
+8. 新建 P1 result 文档，记录实现文件、命令、输出、normalizer 摘要和是否允许进入 P2。
+
+## 失败处理
+
+```text
+样本数不等于 2910/226/508:
+  先查 T>=150 过滤和 split 文件，不改协议。
+
+shape 不等于 [30,2,147] / [120,2,147]:
+  先查 active vector 映射和 crop 边界。
+
+finite 检查失败:
+  先查 H5 原始数值，再查 active vector 和 normalizer std 防护。
+
+train start 不变化:
+  先确认样本 T>150，再查 train crop 随机逻辑。
+
+val/test start 不固定:
+  修 dataset center crop，不进入 P2。
+
+normalizer roundtrip 失败:
+  先查 mean/std shape 和 broadcast 维度。
+```
+
+## P1 退出条件
+
+只有同时满足以下条件，才允许进入 P2：
+
+```text
+P1 smoke 命令成功退出。
+normalizer.pt / normalizer.json 已生成。
+P1 result 文档已新建。
+AGENTS.md 已记录 P1 完成状态和下一步。
+没有修改旧 diffusion / CMDM / ccollate 主路径。
+```

--- a/docs/ai/context/20260603-191712-forecasting-p1-dataset-result.md
+++ b/docs/ai/context/20260603-191712-forecasting-p1-dataset-result.md
@@ -1,0 +1,189 @@
+# Forecasting P1 Dataset + Normalizer 结果记录
+
+## 文档定位
+
+本文记录 P1 实现与验收结果，引用以下上游文档：
+
+```text
+docs/ai/context/20260603-190003-forecasting-final-official-design.md
+docs/ai/context/20260603-190529-forecasting-p1-plan.md
+```
+
+P1 目标是建立 InterHuman forecasting 的唯一数据协议，不进入 P2 metrics / repeat baseline。
+
+## 实现文件
+
+新增文件：
+
+```text
+utils/forecasting_motion.py
+data_loaders/forecasting/__init__.py
+data_loaders/forecasting/interhuman.py
+data_loaders/forecasting/tensors.py
+eval/eval_forecasting.py
+```
+
+未修改旧主路径：
+
+```text
+train/train_mdm.py
+model/cmdm.py
+diffusion/gaussian_diffusion.py
+eval/eval_cmdm.py
+data_loaders/tensors.py::ccollate
+```
+
+## 已实现内容
+
+### Active vector
+
+实现：
+
+```text
+extract_active_motion(motion_h5) -> [T,2,147]
+restore_active_motion(active) -> [T,25,12]
+```
+
+映射：
+
+```text
+actor:   motion[:, :24, 0:6] + motion[:, 24, 0:3]
+reactor: motion[:, :24, 6:12] + motion[:, 24, 6:9]
+```
+
+restore 只还原有效 channel，其他 channel 保持 0。
+
+### Dataset
+
+实现：
+
+```text
+InterHumanForecastDataset
+```
+
+输出：
+
+```text
+obs:    [30,2,147]
+target: [120,2,147]
+meta: sample_id / start / length
+```
+
+采样规则：
+
+```text
+train: random crop 150 frames
+val/test: center crop 150 frames
+T < 150: 过滤
+```
+
+### Collate
+
+实现：
+
+```text
+forecasting_collate(batch) -> obs, target, meta
+```
+
+不做 padding。
+
+### Normalizer
+
+实现：
+
+```text
+ForecastingNormalizer
+compute_forecasting_normalizer
+load_forecasting_normalizer
+```
+
+统计来源：
+
+```text
+train split only
+T>=150 train sequences
+每条可用序列的全部帧
+active vector original scale
+```
+
+保存：
+
+```text
+save/forecasting/interhuman/p1_dataset_smoke/normalizer.pt
+save/forecasting/interhuman/p1_dataset_smoke/normalizer.json
+```
+
+## 验收命令
+
+```bash
+micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m eval.eval_forecasting \
+  --mode dataset_smoke \
+  --dataset interhuman \
+  --data_path dataset/interhuman/smpl/conditioned \
+  --window_len 150 \
+  --obs_len 30 \
+  --pred_len 120 \
+  --batch_size 4 \
+  --num_workers 0 \
+  --save_dir save/forecasting/interhuman/p1_dataset_smoke
+```
+
+## 验收结果
+
+命令已成功退出。
+
+数据集长度：
+
+```text
+train: 2910
+val:   226
+test:  508
+```
+
+batch shape：
+
+```text
+obs:    [4,30,2,147]
+target: [4,120,2,147]
+```
+
+roundtrip：
+
+```text
+active -> h5-like -> active max_abs_error = 0.0
+normalize -> denormalize max_abs_error = 1.1920928955078125e-07
+```
+
+start 规则：
+
+```text
+train 同一样本多次读取 start 可变化。
+val/test 同一样本多次读取 start 固定。
+```
+
+normalizer 摘要：
+
+```text
+num_train_sequences_used: 2910
+num_train_frames_used: 1481944
+person_dim: 147
+eps: 1e-6
+```
+
+输出文件：
+
+```text
+save/forecasting/interhuman/p1_dataset_smoke/dataset_smoke_summary.json
+save/forecasting/interhuman/p1_dataset_smoke/normalizer.json
+save/forecasting/interhuman/p1_dataset_smoke/normalizer.pt
+```
+
+## 结论
+
+P1 已完成，允许进入 P2：
+
+```text
+Metrics + Repeat Baseline
+```
+
+P2 必须继续使用本 P1 的 `InterHumanForecastDataset`、`forecasting_collate`、active vector 和 normalizer，不得重新定义数据协议。

--- a/eval/eval_forecasting.py
+++ b/eval/eval_forecasting.py
@@ -1,0 +1,248 @@
+import argparse
+import json
+import os
+
+import h5py
+import torch
+from torch.utils.data import DataLoader
+
+from data_loaders.forecasting import InterHumanForecastDataset, forecasting_collate
+from utils.forecasting_motion import (
+    PERSON_DIM,
+    compute_forecasting_normalizer,
+    extract_active_motion,
+    load_forecasting_normalizer,
+    restore_active_motion,
+)
+
+
+EXPECTED_LENGTHS = {
+    "train": 2910,
+    "val": 226,
+    "test": 508,
+}
+
+
+def _assert_equal(name, actual, expected):
+    if actual != expected:
+        raise AssertionError("{} 应为 {}，实际为 {}".format(name, expected, actual))
+
+
+def _assert_shape(name, tensor, expected):
+    actual = tuple(tensor.shape)
+    if actual != tuple(expected):
+        raise AssertionError("{} shape 应为 {}，实际为 {}".format(name, expected, actual))
+
+
+def _build_dataset(args, split):
+    return InterHumanForecastDataset(
+        data_path=args.data_path,
+        split=split,
+        window_len=args.window_len,
+        obs_len=args.obs_len,
+        pred_len=args.pred_len,
+        max_samples=args.max_samples,
+        seed=args.seed,
+    )
+
+
+def _check_dataset_lengths(datasets, max_samples):
+    summary = {}
+    for split, dataset in datasets.items():
+        expected = EXPECTED_LENGTHS[split]
+        if max_samples is not None and max_samples > 0:
+            expected = min(expected, max_samples)
+        _assert_equal("{} dataset length".format(split), len(dataset), expected)
+        summary[split] = len(dataset)
+    return summary
+
+
+def _check_item_shapes_and_finite(datasets, obs_len, pred_len):
+    for split, dataset in datasets.items():
+        item = dataset[0]
+        _assert_shape("{} obs".format(split), item["obs"], (obs_len, 2, PERSON_DIM))
+        _assert_shape("{} target".format(split), item["target"], (pred_len, 2, PERSON_DIM))
+        if not torch.isfinite(item["obs"]).all():
+            raise AssertionError("{} obs 存在非有限数值".format(split))
+        if not torch.isfinite(item["target"]).all():
+            raise AssertionError("{} target 存在非有限数值".format(split))
+
+
+def _scan_all_finite(dataset):
+    with h5py.File(str(dataset.h5_path), "r") as h5:
+        for entry in dataset.entries:
+            sample_id = entry["sample_id"]
+            motion = torch.from_numpy(h5[sample_id][:]).float()
+            active = extract_active_motion(motion)
+            if not torch.isfinite(active).all():
+                raise AssertionError(
+                    "{} split sample_id={} 存在非有限数值".format(dataset.split, sample_id)
+                )
+
+
+def _check_all_finite(datasets):
+    for dataset in datasets.values():
+        _scan_all_finite(dataset)
+
+
+def _find_variable_start_index(dataset):
+    for index, entry in enumerate(dataset.entries):
+        if int(entry["length"]) > dataset.window_len:
+            return index
+    return None
+
+
+def _check_start_rules(train_dataset, val_dataset, test_dataset):
+    train_index = _find_variable_start_index(train_dataset)
+    if train_index is None:
+        raise AssertionError("train split 没有 length > window_len 的样本，无法检查随机 start")
+
+    train_starts = [train_dataset[train_index]["start"] for _ in range(64)]
+    if len(set(train_starts)) <= 1:
+        raise AssertionError("train 同一样本多次读取 start 未变化")
+
+    fixed_summary = {}
+    for dataset in (val_dataset, test_dataset):
+        item_starts = [dataset[0]["start"] for _ in range(8)]
+        if len(set(item_starts)) != 1:
+            raise AssertionError("{} 同一样本多次读取 start 不固定".format(dataset.split))
+        expected = (int(dataset.entries[0]["length"]) - dataset.window_len) // 2
+        _assert_equal("{} center start".format(dataset.split), item_starts[0], expected)
+        fixed_summary[dataset.split] = item_starts[0]
+
+    return {
+        "train_checked_index": int(train_index),
+        "train_unique_starts": sorted([int(value) for value in set(train_starts)]),
+        "fixed_eval_starts": fixed_summary,
+    }
+
+
+def _check_batch(dataset, batch_size, num_workers, obs_len, pred_len):
+    loader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        collate_fn=forecasting_collate,
+    )
+    obs, target, meta = next(iter(loader))
+    _assert_shape("batch obs", obs, (min(batch_size, len(dataset)), obs_len, 2, PERSON_DIM))
+    _assert_shape("batch target", target, (min(batch_size, len(dataset)), pred_len, 2, PERSON_DIM))
+    if not isinstance(meta, list) or len(meta) != obs.shape[0]:
+        raise AssertionError("batch meta 长度不正确")
+    if not torch.isfinite(obs).all() or not torch.isfinite(target).all():
+        raise AssertionError("batch obs/target 存在非有限数值")
+    return {
+        "obs_shape": list(obs.shape),
+        "target_shape": list(target.shape),
+        "meta_size": len(meta),
+    }
+
+
+def _check_active_roundtrip(dataset):
+    item = dataset[0]
+    active = torch.cat([item["obs"], item["target"]], dim=0)
+    restored = restore_active_motion(active)
+    recovered = extract_active_motion(restored)
+    max_abs_error = float((active - recovered).abs().max().item())
+    if max_abs_error > 1e-5:
+        raise AssertionError("active roundtrip 误差过大: {}".format(max_abs_error))
+    return max_abs_error
+
+
+def _check_normalizer(args, dataset):
+    normalizer = compute_forecasting_normalizer(
+        data_path=args.data_path,
+        save_dir=args.save_dir,
+        window_len=args.window_len,
+        obs_len=args.obs_len,
+        pred_len=args.pred_len,
+    )
+    loaded = load_forecasting_normalizer(args.save_dir)
+
+    item = dataset[0]
+    active = torch.cat([item["obs"], item["target"]], dim=0)
+    restored = loaded.denormalize(loaded.normalize(active))
+    max_abs_error = float((active - restored).abs().max().item())
+    if max_abs_error > 1e-5:
+        raise AssertionError("normalize -> denormalize 误差过大: {}".format(max_abs_error))
+
+    pt_path = os.path.join(args.save_dir, "normalizer.pt")
+    json_path = os.path.join(args.save_dir, "normalizer.json")
+    if not os.path.exists(pt_path) or not os.path.exists(json_path):
+        raise AssertionError("normalizer.pt 或 normalizer.json 未生成")
+
+    return {
+        "roundtrip_max_abs_error": max_abs_error,
+        "metadata": normalizer.metadata,
+    }
+
+
+def run_dataset_smoke(args):
+    if args.dataset != "interhuman":
+        raise ValueError("P1 只支持 interhuman dataset")
+
+    os.makedirs(args.save_dir, exist_ok=True)
+    datasets = {
+        "train": _build_dataset(args, "train"),
+        "val": _build_dataset(args, "val"),
+        "test": _build_dataset(args, "test"),
+    }
+
+    summary = {
+        "mode": "dataset_smoke",
+        "dataset": args.dataset,
+        "data_path": args.data_path,
+        "window_len": args.window_len,
+        "obs_len": args.obs_len,
+        "pred_len": args.pred_len,
+        "dataset_lengths": _check_dataset_lengths(datasets, args.max_samples),
+    }
+    _check_item_shapes_and_finite(datasets, args.obs_len, args.pred_len)
+    _check_all_finite(datasets)
+    summary["start_rules"] = _check_start_rules(
+        datasets["train"], datasets["val"], datasets["test"]
+    )
+    summary["batch"] = _check_batch(
+        datasets["train"], args.batch_size, args.num_workers, args.obs_len, args.pred_len
+    )
+    summary["active_roundtrip_max_abs_error"] = _check_active_roundtrip(datasets["train"])
+    summary["normalizer"] = _check_normalizer(args, datasets["train"])
+
+    summary_path = os.path.join(args.save_dir, "dataset_smoke_summary.json")
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2, sort_keys=True)
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return summary
+
+
+def build_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True, choices=["dataset_smoke"])
+    parser.add_argument("--dataset", default="interhuman")
+    parser.add_argument("--data_path", default="dataset/interhuman/smpl/conditioned")
+    parser.add_argument("--window_len", type=int, default=150)
+    parser.add_argument("--obs_len", type=int, default=30)
+    parser.add_argument("--pred_len", type=int, default=120)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--num_workers", type=int, default=0)
+    parser.add_argument("--max_samples", type=int, default=-1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--save_dir",
+        default="save/forecasting/interhuman/p1_dataset_smoke",
+    )
+    return parser
+
+
+def main():
+    args = build_arg_parser().parse_args()
+    if args.mode == "dataset_smoke":
+        run_dataset_smoke(args)
+        return
+    raise ValueError("unsupported mode: {}".format(args.mode))
+
+
+if __name__ == "__main__":
+    main()

--- a/preprocess/interhuman_as.py
+++ b/preprocess/interhuman_as.py
@@ -1,0 +1,240 @@
+import argparse
+import json
+import os
+import pickle
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+import h5py
+import numpy as np
+import torch
+
+sys.path.append("./")
+import utils.rotation_conversions as geometry
+
+
+SPLITS = ("train", "val", "test")
+PERSON_KEYS = ("trans", "root_orient", "pose_body")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Convert InterHuman-AS pkl files to frozen ReGenNet H5 files."
+    )
+    parser.add_argument(
+        "--data_root",
+        default="dataset/interhuman",
+        help="InterHuman root containing motions, split and annotations_interhuman.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        default="dataset/interhuman/smpl/conditioned",
+        help="Directory for interhuman_{split}.h5 and meta.json.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing output files.",
+    )
+    return parser.parse_args()
+
+
+def read_split_ids(split_dir, split):
+    with (split_dir / f"{split}.txt").open("r") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def load_labels(label_path):
+    with label_path.open("r") as f:
+        return {str(k): int(v) for k, v in json.load(f).items()}
+
+
+def finite_array(value):
+    array = np.asarray(value)
+    return np.isfinite(array).all()
+
+
+def validate_person(person, frames, person_name):
+    expected_shapes = {
+        "trans": (frames, 3),
+        "root_orient": (frames, 3),
+        "pose_body": (frames, 63),
+    }
+    for key in PERSON_KEYS:
+        if key not in person:
+            return False, f"missing_{person_name}_{key}"
+        array = np.asarray(person[key])
+        if array.shape != expected_shapes[key]:
+            return False, f"invalid_shape_{person_name}_{key}:{array.shape}"
+        if not finite_array(array):
+            return False, f"non_finite_{person_name}_{key}"
+    return True, "ok"
+
+
+def load_valid_item(motion_dir, labels, sample_id):
+    path = motion_dir / f"{sample_id}.pkl"
+    if not path.exists():
+        return None, "missing_motion_file"
+    if sample_id not in labels:
+        return None, "missing_actor_reactor_label"
+    if labels[sample_id] not in (0, 1):
+        return None, f"invalid_actor_reactor_label:{labels[sample_id]}"
+
+    try:
+        with path.open("rb") as f:
+            item = pickle.load(f)
+    except Exception as exc:
+        return None, f"pickle_load_error:{type(exc).__name__}"
+
+    frames = int(item.get("frames", 0))
+    if frames <= 0:
+        return None, "non_positive_frames"
+
+    for person_name in ("person1", "person2"):
+        if person_name not in item:
+            return None, f"missing_{person_name}"
+        ok, reason = validate_person(item[person_name], frames, person_name)
+        if not ok:
+            return None, reason
+
+    return item, "ok"
+
+
+def person_axis_angle(person):
+    root = np.asarray(person["root_orient"], dtype=np.float32)
+    body = np.asarray(person["pose_body"], dtype=np.float32)
+    pad = np.zeros((root.shape[0], 6), dtype=np.float32)
+    return np.concatenate([root, body, pad], axis=1).reshape(root.shape[0], 24, 3)
+
+
+def axis_angle_to_rot6d(axis_angle):
+    tensor = torch.from_numpy(axis_angle.astype(np.float32))
+    with torch.no_grad():
+        rot6d = geometry.matrix_to_rotation_6d(geometry.axis_angle_to_matrix(tensor))
+    return rot6d.cpu().numpy().astype(np.float32)
+
+
+def ordered_people(item, label):
+    person1, person2 = item["person1"], item["person2"]
+    if label == 1:
+        return person2, person1
+    return person1, person2
+
+
+def convert_item(item, label):
+    actor, reactor = ordered_people(item, label)
+    actor_rot6d = axis_angle_to_rot6d(person_axis_angle(actor))
+    reactor_rot6d = axis_angle_to_rot6d(person_axis_angle(reactor))
+
+    # 与在线 loader 一致，原因是双人相对位移需要共享同一个世界原点。
+    origin = np.asarray(actor["trans"], dtype=np.float32)[0].copy()
+    actor_trans = np.asarray(actor["trans"], dtype=np.float32) - origin
+    reactor_trans = np.asarray(reactor["trans"], dtype=np.float32) - origin
+
+    frames = actor_rot6d.shape[0]
+    output = np.zeros((frames, 25, 12), dtype=np.float32)
+    output[:, :24, 0:6] = actor_rot6d
+    output[:, :24, 6:12] = reactor_rot6d
+    output[:, 24, 0:3] = actor_trans
+    output[:, 24, 6:9] = reactor_trans
+    return output
+
+
+def output_paths(output_dir):
+    paths = {split: output_dir / f"interhuman_{split}.h5" for split in SPLITS}
+    paths["meta"] = output_dir / "meta.json"
+    return paths
+
+
+def ensure_can_write(paths, overwrite):
+    existing = [str(path) for path in paths.values() if path.exists()]
+    if existing and not overwrite:
+        raise FileExistsError(
+            "Output files already exist. Use --overwrite to replace them: "
+            + ", ".join(existing)
+        )
+
+
+def write_split(split, ids, motion_dir, labels, output_path):
+    skipped = []
+    shapes = {}
+    written = 0
+    with h5py.File(output_path, "w") as h5:
+        for sample_id in ids:
+            item, reason = load_valid_item(motion_dir, labels, sample_id)
+            if item is None:
+                skipped.append({"id": sample_id, "reason": reason})
+                continue
+            value = convert_item(item, labels[sample_id])
+            if not np.isfinite(value).all():
+                skipped.append({"id": sample_id, "reason": "converted_non_finite"})
+                continue
+            h5.create_dataset(sample_id, data=value, dtype="f4")
+            shapes[sample_id] = list(value.shape)
+            written += 1
+
+    reason_counter = Counter(entry["reason"] for entry in skipped)
+    return {
+        "listed": len(ids),
+        "written": written,
+        "skipped": len(skipped),
+        "skip_reasons": dict(reason_counter),
+        "skipped_samples": skipped,
+        "shapes": {
+            "first_samples": dict(list(shapes.items())[:10]),
+            "unique": sorted({tuple(shape) for shape in shapes.values()}),
+        },
+    }
+
+
+def main():
+    args = parse_args()
+    data_root = Path(args.data_root)
+    output_dir = Path(args.output_dir)
+    motion_dir = data_root / "motions"
+    split_dir = data_root / "split"
+    label_path = data_root / "annotations_interhuman" / "interhuman_label.json"
+
+    paths = output_paths(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ensure_can_write(paths, args.overwrite)
+
+    labels = load_labels(label_path)
+    split_ids = {split: read_split_ids(split_dir, split) for split in SPLITS}
+
+    meta = {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "data_root": str(data_root),
+        "output_dir": str(output_dir),
+        "format": {
+            "shape": "[T,25,12]",
+            "rotation": "rot6d",
+            "body_model": "smpl",
+            "translation_slot": 24,
+            "translation_origin": "actor frame 0",
+            "channels": {
+                "actor_rot6d": "[:, :24, 0:6]",
+                "actor_translation": "[:, 24, 0:3]",
+                "reactor_rot6d": "[:, :24, 6:12]",
+                "reactor_translation": "[:, 24, 6:9]",
+            },
+        },
+        "splits": {},
+    }
+
+    for split in SPLITS:
+        print(f"Writing {split} -> {paths[split]}")
+        meta["splits"][split] = write_split(
+            split, split_ids[split], motion_dir, labels, paths[split]
+        )
+
+    with paths["meta"].open("w") as f:
+        json.dump(meta, f, indent=2, ensure_ascii=False, sort_keys=True)
+
+    print(json.dumps(meta["splits"], indent=2, ensure_ascii=False, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/render/crendermotion.py
+++ b/render/crendermotion.py
@@ -122,7 +122,7 @@ def main():
         action = actions[ind]
         # print("vidmeshes ", vidmeshes.shape)
         # meshes = vidmeshes.transpose(2, 0, 1)
-        meshes = torch.permute(vidmeshes, (2, 0, 1)).cpu()
+        meshes = vidmeshes.permute(2, 0, 1).cpu()
         # meshes: [T, 6890, 3]
         path = os.path.join(savefolder, "{}_{}.mp4".format(action, ind))
         render_video(meshes, ind, action, renderer, path, background, num_person)

--- a/render/renderer.py
+++ b/render/renderer.py
@@ -4,7 +4,7 @@ Adhere to their licence to use this script
 It has been modified
 """
 import os
-os.environ['PYOPENGL_PLATFORM'] = 'osmesa'
+os.environ.setdefault('PYOPENGL_PLATFORM', 'egl')
 import math
 import trimesh
 import pyrender
@@ -141,7 +141,7 @@ class Renderer:
 
         rgb, _ = self.renderer.render(self.scene, flags=render_flags)
         valid_mask = (rgb[:, :, -1] > 0)[:, :, np.newaxis]
-        output_img = rgb * valid_mask + (1 - valid_mask) * img
+        output_img = rgb[:, :, :3] * valid_mask + (1 - valid_mask) * img
         image = output_img.astype(np.uint8)
         for mesh_node in mesh_node_list:
             self.scene.remove_node(mesh_node)

--- a/train/train_mdm.py
+++ b/train/train_mdm.py
@@ -1,6 +1,9 @@
-# This code is based on https://github.com/openai/guided-diffusion
+# 本文件基于 https://github.com/openai/guided-diffusion 改写。
 """
-Train a diffusion model on images.
+训练扩散模型的入口脚本。
+
+在 ReGenNet 中，这个脚本负责把“参数解析、数据加载、模型构建、扩散过程构建、训练循环”
+串起来。真正的网络结构在 model/cmdm.py，真正的训练步在 train/training_loop.py。
 """
 
 import os
@@ -11,17 +14,24 @@ from utils import dist_util
 from train.training_loop import TrainLoop
 from data_loaders.get_data import get_dataset_loader
 from utils.model_util import create_model_and_diffusion
-from train.train_platforms import ClearmlPlatform, TensorboardPlatform, NoPlatform  # required for the eval operation
+from train.train_platforms import ClearmlPlatform, TensorboardPlatform, NoPlatform  # 评估流程需要这些日志平台类
 from torch.nn.parallel.distributed import DistributedDataParallel as DDP
 from mpi4py import MPI
 
 def main():
+    # 1. 解析训练命令行参数，参数定义在 utils/parser_util.py 的 train_args()。
     args = train_args()
+
+    # 2. 固定随机种子，保证实验尽量可复现。
     fixseed(args.seed)
+
+    # 3. 根据参数选择训练日志平台，例如 TensorBoard、ClearML 或不记录。
     train_platform_type = eval(args.train_platform_type)
     train_platform = train_platform_type(args.save_dir)
     train_platform.report_args(args, name='Args')
 
+    # 4. 检查并创建保存目录，同时把本次训练参数保存为 args.json。
+    #    后续采样、评估会从 checkpoint 同目录的 args.json 恢复模型配置。
     if args.save_dir is None:
         raise FileNotFoundError('save_dir was not specified.')
     elif os.path.exists(args.save_dir) and not args.overwrite:
@@ -32,29 +42,46 @@ def main():
     with open(args_path, 'w') as fw:
         json.dump(vars(args), fw, indent=4, sort_keys=True)
 
+    # 5. 初始化分布式训练环境。单 GPU 训练时也会走这套初始化逻辑。
     dist_util.setup_dist()
 
     print("creating data loader...")
+
+    # 6. 根据架构名称判断是离线生成模式还是在线自回归模式。
+    #    online/trans_dec 使用 Transformer Decoder；offline/trans_enc 使用 Transformer Encoder。
     if args.arch == 'trans_enc' or args.arch == 'mlp' or args.arch == 'gru' or args.arch == 'offline':
         arch_mode = 'offline'
     elif args.arch == 'trans_dec' or args.arch == 'online':
         arch_mode = 'online'
+
+    # 7. unconstrained=True 表示不使用动作类别或文本作为条件；
+    #    对 ReGenNet 的 cmdm 设置来说，仍然会使用另一人的动作 cmotion 作为条件。
     if args.unconstrained:
         action_conditioned = False
     else:
         action_conditioned = True
     print("Setting:", args.setting, "| Dataset:", args.dataset, "| Arch:", arch_mode, "| Action conditioned:", action_conditioned)
+
+    # 8. 创建训练数据加载器。
+    #    对 cmdm 双人动作数据，后续 collate 会把 actor 动作拆到 cond['y']['cmotion']，
+    #    reactor 动作作为 motion 训练目标。
     data = get_dataset_loader(name=args.dataset, batch_size=args.batch_size, num_frames=args.num_frames, 
                               num_person=args.num_person, data_path = args.data_path, pose_rep = args.pose_rep, body_model=args.body_model, setting=args.setting, ar_shuffle=args.shuffle,
-                              shard=MPI.COMM_WORLD.Get_rank(), num_shards=MPI.COMM_WORLD.Get_size())
+                              shard=MPI.COMM_WORLD.Get_rank(), num_shards=MPI.COMM_WORLD.Get_size(), max_samples=args.max_samples)
 
     print("creating model and diffusion...")
+
+    # 9. 根据参数和数据集元信息创建 CMDM 模型与 Gaussian Diffusion 训练过程。
     model, diffusion = create_model_and_diffusion(args, data)
     model.to(dist_util.dev())
+
+    # 10. rot2xyz 内部包含 SMPL/SMPL-X 模型，这里切到 eval，避免训练人体模型参数。
     model.rot2xyz.smpl_model.eval()
 
     print('Total params: %.2fM' % (sum(p.numel() for p in model.parameters_wo_clip()) / 1000000.0))
     print("Training...")
+
+    # 11. 进入训练循环。每一步训练、loss 计算、反向传播、保存 checkpoint 都在 TrainLoop 中完成。
     TrainLoop(args, train_platform, model, diffusion, data).run_loop()
     train_platform.close()
 

--- a/train/training_loop.py
+++ b/train/training_loop.py
@@ -56,12 +56,11 @@ class TrainLoop:
         self.resume_step = 0
         self.global_batch = self.batch_size * dist.get_world_size()
         self.num_steps = args.num_steps
-        self.num_epochs = self.num_steps // (len(self.data) * dist.get_world_size() + 1)
-        # self.num_epochs = self.num_steps // (len(self.data) + 1)
 
         self.sync_cuda = torch.cuda.is_available()
 
         self._load_and_sync_parameters()
+        self.num_epochs = self._estimate_num_epochs()
         self.mp_trainer = MixedPrecisionTrainer(
             model=self.model,
             use_fp16=self.use_fp16,
@@ -131,6 +130,17 @@ class TrainLoop:
             self.use_ddp = False
             self.ddp_model = self.model
 
+    def _estimate_num_epochs(self):
+        remaining_steps = max(self.num_steps - self.resume_step, 0)
+        steps_per_epoch = max(len(self.data), 1)
+        return max(int(np.ceil(remaining_steps / steps_per_epoch)), 0)
+
+    def _training_finished(self):
+        return self.step + self.resume_step >= self.num_steps
+
+    def _lr_anneal_finished(self):
+        return self.lr_anneal_steps and self.step + self.resume_step >= self.lr_anneal_steps
+
     def _load_and_sync_parameters(self):
         resume_checkpoint = find_resume_checkpoint() or self.resume_checkpoint
 
@@ -176,44 +186,52 @@ class TrainLoop:
 
         for epoch in range(self.num_epochs):
             print(f'Starting epoch {epoch}:{self.num_epochs}')
-            for motion, cond in tqdm(self.data):
-                if not (not self.lr_anneal_steps or self.step + self.resume_step < self.lr_anneal_steps):
-                    break
+            data_iter = iter(self.data)
+            progress = tqdm(data_iter, total=len(self.data))
+            try:
+                for motion, cond in progress:
+                    if self._training_finished() or self._lr_anneal_finished():
+                        break
 
-                motion = motion.to(self.device) # [B=64, 25, 6, T=60]
-                """
-                    cond['y']['mask']: [64, 1, 1, 60]
-                    cond['y']['lengths']: [64]
-                    cond['y']['action']: [64, 1]
-                    cond['y']['action_text']: [64, 1]
-                """
-                cond['y'] = {key: val.to(self.device) if torch.is_tensor(val) else val for key, val in cond['y'].items()}
+                    motion = motion.to(self.device) # [B=64, 25, 6, T=60]
+                    """
+                        cond['y']['mask']: [64, 1, 1, 60]
+                        cond['y']['lengths']: [64]
+                        cond['y']['action']: [64, 1]
+                        cond['y']['action_text']: [64, 1]
+                    """
+                    cond['y'] = {key: val.to(self.device) if torch.is_tensor(val) else val for key, val in cond['y'].items()}
 
-                self.run_step(motion, cond)
-                if self.step % self.log_interval == 0:
-                    for k,v in logger.get_current().name2val.items():
-                        if k == 'loss':
-                            print('step[{}]: loss[{:0.5f}]'.format(self.step+self.resume_step, v))
+                    self.run_step(motion, cond)
+                    if self.step % self.log_interval == 0:
+                        for k,v in logger.get_current().name2val.items():
+                            if k == 'loss':
+                                print('step[{}]: loss[{:0.5f}]'.format(self.step+self.resume_step, v))
 
-                        if k in ['step', 'samples'] or '_q' in k:
-                            continue
-                        else:
-                            self.train_platform.report_scalar(name=k, value=v, iteration=self.step, group_name='Loss')
+                            if k in ['step', 'samples'] or '_q' in k:
+                                continue
+                            else:
+                                self.train_platform.report_scalar(name=k, value=v, iteration=self.step, group_name='Loss')
 
-                if self.step % self.save_interval == 0:
-                    self.save()
-                    self.model.eval()
-                    self.evaluate()
-                    self.model.train()
+                    if self.step % self.save_interval == 0:
+                        self.save()
+                        self.model.eval()
+                        self.evaluate()
+                        self.model.train()
 
-                    # Run for a finite amount of time in integration tests.
-                    if os.environ.get("DIFFUSION_TRAINING_TEST", "") and self.step > 0:
-                        return
-                self.step += 1
-            if not (not self.lr_anneal_steps or self.step + self.resume_step < self.lr_anneal_steps):
+                        # Run for a finite amount of time in integration tests.
+                        if os.environ.get("DIFFUSION_TRAINING_TEST", "") and self.step > 0:
+                            return
+                    self.step += 1
+            finally:
+                progress.close()
+                shutdown_workers = getattr(data_iter, "_shutdown_workers", None)
+                if shutdown_workers is not None:
+                    shutdown_workers()
+            if self._training_finished() or self._lr_anneal_finished():
                 break
         # Save the last checkpoint if it wasn't already saved.
-        if (self.step - 1) % self.save_interval != 0:
+        if self.step > 0 and (self.step - 1) % self.save_interval != 0:
             self.save()
             self.evaluate()
 

--- a/train/training_loop.py
+++ b/train/training_loop.py
@@ -1,4 +1,5 @@
 import copy
+import contextlib
 import functools
 import os
 import time
@@ -38,6 +39,7 @@ class TrainLoop:
         self.data = data
         self.batch_size = args.batch_size
         self.microbatch = args.batch_size  # deprecating this option
+        self.grad_accum_steps = max(1, int(getattr(args, 'grad_accum_steps', 1)))
         self.lr = args.lr
         self.ema_rate = "0.9999"
         self.log_interval = args.log_interval
@@ -54,7 +56,9 @@ class TrainLoop:
         )
         self.step = 0
         self.resume_step = 0
-        self.global_batch = self.batch_size * dist.get_world_size()
+        self.data_step = 0
+        self.accumulated_batches = 0
+        self.global_batch = self.batch_size * dist.get_world_size() * self.grad_accum_steps
         self.num_steps = args.num_steps
 
         self.sync_cuda = torch.cuda.is_available()
@@ -133,7 +137,8 @@ class TrainLoop:
     def _estimate_num_epochs(self):
         remaining_steps = max(self.num_steps - self.resume_step, 0)
         steps_per_epoch = max(len(self.data), 1)
-        return max(int(np.ceil(remaining_steps / steps_per_epoch)), 0)
+        required_data_steps = remaining_steps * self.grad_accum_steps
+        return max(int(np.ceil(required_data_steps / steps_per_epoch)), 0)
 
     def _training_finished(self):
         return self.step + self.resume_step >= self.num_steps
@@ -202,27 +207,28 @@ class TrainLoop:
                     """
                     cond['y'] = {key: val.to(self.device) if torch.is_tensor(val) else val for key, val in cond['y'].items()}
 
-                    self.run_step(motion, cond)
-                    if self.step % self.log_interval == 0:
-                        for k,v in logger.get_current().name2val.items():
-                            if k == 'loss':
-                                print('step[{}]: loss[{:0.5f}]'.format(self.step+self.resume_step, v))
+                    optimized = self.run_step(motion, cond)
+                    if optimized:
+                        if self.step % self.log_interval == 0:
+                            for k,v in logger.get_current().name2val.items():
+                                if k == 'loss':
+                                    print('step[{}]: loss[{:0.5f}]'.format(self.step+self.resume_step, v))
 
-                            if k in ['step', 'samples'] or '_q' in k:
-                                continue
-                            else:
-                                self.train_platform.report_scalar(name=k, value=v, iteration=self.step, group_name='Loss')
+                                if k in ['step', 'samples', 'data_step', 'effective_batch_size'] or '_q' in k:
+                                    continue
+                                else:
+                                    self.train_platform.report_scalar(name=k, value=v, iteration=self.step, group_name='Loss')
 
-                    if self.step % self.save_interval == 0:
-                        self.save()
-                        self.model.eval()
-                        self.evaluate()
-                        self.model.train()
+                        if self.step % self.save_interval == 0:
+                            self.save()
+                            self.model.eval()
+                            self.evaluate()
+                            self.model.train()
 
-                        # Run for a finite amount of time in integration tests.
-                        if os.environ.get("DIFFUSION_TRAINING_TEST", "") and self.step > 0:
-                            return
-                    self.step += 1
+                            # Run for a finite amount of time in integration tests.
+                            if os.environ.get("DIFFUSION_TRAINING_TEST", "") and self.step > 0:
+                                return
+                        self.step += 1
             finally:
                 progress.close()
                 shutdown_workers = getattr(data_iter, "_shutdown_workers", None)
@@ -276,13 +282,29 @@ class TrainLoop:
 
 
     def run_step(self, batch, cond):
-        self.forward_backward(batch, cond)
+        if self.accumulated_batches == 0:
+            self.mp_trainer.zero_grad()
+
+        self.accumulated_batches += 1
+        self.data_step += 1
+        sync_grad = self.accumulated_batches == self.grad_accum_steps
+
+        self.forward_backward(
+            batch,
+            cond,
+            sync_grad=sync_grad,
+            loss_scale=1.0 / self.grad_accum_steps,
+        )
+        if not sync_grad:
+            return False
+
         self.mp_trainer.optimize(self.opt)
         self._anneal_lr()
         self.log_step()
+        self.accumulated_batches = 0
+        return True
 
-    def forward_backward(self, batch, cond):
-        self.mp_trainer.zero_grad()
+    def forward_backward(self, batch, cond, sync_grad=True, loss_scale=1.0):
         for i in range(0, batch.shape[0], self.microbatch):
             # Eliminates the microbatch feature
             assert i == 0
@@ -302,22 +324,24 @@ class TrainLoop:
                 dataset=self.data.dataset
             )
 
-            if last_batch or not self.use_ddp:
-                losses = compute_losses()
-            else:
-                with self.ddp_model.no_sync():
-                    losses = compute_losses()
-
-            if isinstance(self.schedule_sampler, LossAwareSampler):
-                self.schedule_sampler.update_with_local_losses(
-                    t, losses["loss"].detach()
-                )
-
-            loss = (losses["loss"] * weights).mean()
-            log_loss_dict(
-                self.diffusion, t, {k: v * weights for k, v in losses.items()}
+            context = (
+                contextlib.nullcontext()
+                if sync_grad or not self.use_ddp
+                else self.ddp_model.no_sync()
             )
-            self.mp_trainer.backward(loss)
+            with context:
+                losses = compute_losses()
+
+                if isinstance(self.schedule_sampler, LossAwareSampler):
+                    self.schedule_sampler.update_with_local_losses(
+                        t, losses["loss"].detach()
+                    )
+
+                loss = (losses["loss"] * weights).mean()
+                log_loss_dict(
+                    self.diffusion, t, {k: v * weights for k, v in losses.items()}
+                )
+                self.mp_trainer.backward(loss * loss_scale)
 
     def _anneal_lr(self):
         if not self.lr_anneal_steps:
@@ -329,6 +353,11 @@ class TrainLoop:
 
     def log_step(self):
         logger.logkv("step", self.step + self.resume_step)
+        logger.logkv(
+            "data_step",
+            (self.step + self.resume_step) * self.grad_accum_steps + self.accumulated_batches,
+        )
+        logger.logkv("effective_batch_size", self.global_batch)
         logger.logkv("samples", (self.step + self.resume_step + 1) * self.global_batch)
 
 

--- a/utils/forecasting_motion.py
+++ b/utils/forecasting_motion.py
@@ -1,0 +1,215 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import h5py
+import torch
+
+
+NUM_PERSONS = 2
+NUM_BODY_JOINTS = 24
+ROT6D_DIM = 6
+ROT_DIM = NUM_BODY_JOINTS * ROT6D_DIM
+TRANSL_DIM = 3
+PERSON_DIM = ROT_DIM + TRANSL_DIM
+H5_JOINTS = 25
+H5_CHANNELS = 12
+EPS = 1e-6
+
+
+def _as_tensor(value):
+    if isinstance(value, torch.Tensor):
+        return value
+    return torch.as_tensor(value)
+
+
+def _check_motion_h5_shape(motion):
+    if motion.dim() != 3:
+        raise ValueError("motion_h5 必须是 [T,25,12]，当前维度数为 {}".format(motion.dim()))
+    if motion.shape[1] != H5_JOINTS or motion.shape[2] != H5_CHANNELS:
+        raise ValueError(
+            "motion_h5 必须是 [T,25,12]，当前 shape 为 {}".format(tuple(motion.shape))
+        )
+
+
+def _check_active_shape(active):
+    if active.dim() != 3:
+        raise ValueError("active 必须是 [T,2,147]，当前维度数为 {}".format(active.dim()))
+    if active.shape[1] != NUM_PERSONS or active.shape[2] != PERSON_DIM:
+        raise ValueError(
+            "active 必须是 [T,2,147]，当前 shape 为 {}".format(tuple(active.shape))
+        )
+
+
+def extract_active_motion(motion_h5):
+    motion = _as_tensor(motion_h5)
+    _check_motion_h5_shape(motion)
+    num_frames = motion.shape[0]
+
+    actor_rot = motion[:, :NUM_BODY_JOINTS, 0:6].reshape(num_frames, ROT_DIM)
+    actor_trans = motion[:, H5_JOINTS - 1, 0:3]
+    reactor_rot = motion[:, :NUM_BODY_JOINTS, 6:12].reshape(num_frames, ROT_DIM)
+    reactor_trans = motion[:, H5_JOINTS - 1, 6:9]
+
+    actor = torch.cat([actor_rot, actor_trans], dim=-1)
+    reactor = torch.cat([reactor_rot, reactor_trans], dim=-1)
+    return torch.stack([actor, reactor], dim=1).contiguous()
+
+
+def restore_active_motion(active):
+    active = _as_tensor(active)
+    _check_active_shape(active)
+    num_frames = active.shape[0]
+    motion = active.new_zeros((num_frames, H5_JOINTS, H5_CHANNELS))
+
+    motion[:, :NUM_BODY_JOINTS, 0:6] = active[:, 0, :ROT_DIM].reshape(
+        num_frames, NUM_BODY_JOINTS, ROT6D_DIM
+    )
+    motion[:, H5_JOINTS - 1, 0:3] = active[:, 0, ROT_DIM:PERSON_DIM]
+    motion[:, :NUM_BODY_JOINTS, 6:12] = active[:, 1, :ROT_DIM].reshape(
+        num_frames, NUM_BODY_JOINTS, ROT6D_DIM
+    )
+    motion[:, H5_JOINTS - 1, 6:9] = active[:, 1, ROT_DIM:PERSON_DIM]
+    return motion
+
+
+class ForecastingNormalizer(object):
+    def __init__(self, mean, std, eps=EPS, metadata=None):
+        self.mean = _as_tensor(mean)
+        self.std = _as_tensor(std)
+        self.eps = float(eps)
+        self.metadata = metadata or {}
+        self._check_shape()
+
+    def _check_shape(self):
+        expected = (1, 1, NUM_PERSONS, PERSON_DIM)
+        if tuple(self.mean.shape) != expected:
+            raise ValueError("mean shape 必须是 {}，当前为 {}".format(expected, tuple(self.mean.shape)))
+        if tuple(self.std.shape) != expected:
+            raise ValueError("std shape 必须是 {}，当前为 {}".format(expected, tuple(self.std.shape)))
+
+    def _stats_for(self, value):
+        if value.dim() == 3:
+            return self.mean[0].to(value.device), self.std[0].to(value.device)
+        return self.mean.to(value.device), self.std.to(value.device)
+
+    def normalize(self, value):
+        mean, std = self._stats_for(value)
+        return (value - mean.to(dtype=value.dtype)) / std.to(dtype=value.dtype)
+
+    def denormalize(self, value):
+        mean, std = self._stats_for(value)
+        return value * std.to(dtype=value.dtype) + mean.to(dtype=value.dtype)
+
+    def state_dict(self):
+        return {
+            "mean": self.mean,
+            "std": self.std,
+            "eps": self.eps,
+            "metadata": self.metadata,
+        }
+
+
+def _resolve_interhuman_h5(data_path, split):
+    path = Path(data_path)
+    if path.suffix == ".h5":
+        return path
+    return path / "interhuman_{}.h5".format(split)
+
+
+def _normalizer_pt_path(path):
+    path = Path(path)
+    if path.suffix == ".pt":
+        return path
+    return path / "normalizer.pt"
+
+
+def _normalizer_json_path(path):
+    path = Path(path)
+    if path.suffix == ".json":
+        return path
+    if path.suffix == ".pt":
+        return path.with_suffix(".json")
+    return path / "normalizer.json"
+
+
+def compute_forecasting_normalizer(
+    data_path,
+    save_dir=None,
+    window_len=150,
+    obs_len=30,
+    pred_len=120,
+    eps=EPS,
+):
+    if obs_len + pred_len != window_len:
+        raise ValueError("obs_len + pred_len 必须等于 window_len")
+
+    h5_path = _resolve_interhuman_h5(data_path, "train")
+    if not h5_path.exists():
+        raise FileNotFoundError(str(h5_path))
+
+    total_sum = torch.zeros((NUM_PERSONS, PERSON_DIM), dtype=torch.float64)
+    total_sq_sum = torch.zeros((NUM_PERSONS, PERSON_DIM), dtype=torch.float64)
+    num_sequences = 0
+    num_frames = 0
+
+    with h5py.File(str(h5_path), "r") as h5:
+        for key in h5.keys():
+            shape = h5[key].shape
+            length = int(shape[0])
+            if length < window_len:
+                continue
+            motion = torch.from_numpy(h5[key][:]).to(dtype=torch.float64)
+            active = extract_active_motion(motion)
+            if not torch.isfinite(active).all():
+                raise ValueError("normalizer 统计发现非有限数值: sample_id={}".format(key))
+            total_sum += active.sum(dim=0)
+            total_sq_sum += (active * active).sum(dim=0)
+            num_sequences += 1
+            num_frames += length
+
+    if num_sequences == 0 or num_frames == 0:
+        raise ValueError("没有可用于 normalizer 的 train 序列")
+
+    mean = total_sum / float(num_frames)
+    var = total_sq_sum / float(num_frames) - mean * mean
+    var = torch.clamp(var, min=0.0)
+    std = torch.sqrt(var)
+    std = torch.where(std < eps, torch.ones_like(std), std)
+
+    mean = mean.to(dtype=torch.float32).view(1, 1, NUM_PERSONS, PERSON_DIM)
+    std = std.to(dtype=torch.float32).view(1, 1, NUM_PERSONS, PERSON_DIM)
+    metadata = {
+        "dataset": "interhuman",
+        "data_path": str(data_path),
+        "train_h5_path": str(h5_path),
+        "window_len": int(window_len),
+        "obs_len": int(obs_len),
+        "pred_len": int(pred_len),
+        "num_train_sequences_used": int(num_sequences),
+        "num_train_frames_used": int(num_frames),
+        "person_dim": int(PERSON_DIM),
+        "eps": float(eps),
+        "created_at": datetime.utcnow().isoformat() + "Z",
+    }
+    normalizer = ForecastingNormalizer(mean, std, eps=eps, metadata=metadata)
+
+    if save_dir is not None:
+        os.makedirs(str(save_dir), exist_ok=True)
+        torch.save(normalizer.state_dict(), str(_normalizer_pt_path(save_dir)))
+        with open(str(_normalizer_json_path(save_dir)), "w") as f:
+            json.dump(metadata, f, indent=2, sort_keys=True)
+
+    return normalizer
+
+
+def load_forecasting_normalizer(path):
+    pt_path = _normalizer_pt_path(path)
+    state = torch.load(str(pt_path), map_location="cpu")
+    return ForecastingNormalizer(
+        state["mean"],
+        state["std"],
+        eps=state.get("eps", EPS),
+        metadata=state.get("metadata", {}),
+    )

--- a/utils/model_util.py
+++ b/utils/model_util.py
@@ -9,11 +9,23 @@ def load_model_wo_clip(model, state_dict):
 
 
 def create_model_and_diffusion(args, data):
+    # 1. 读取命令行里的训练框架设置；当前 ReGenNet 主路径使用 setting='cmdm'。
     setting = args.setting
+
+    # 2. 如果是 CMDM 框架，就创建条件动作扩散模型。
     if setting == 'cmdm':
+        # 3. get_model_args 会根据命令行参数和数据集信息整理 CMDM 构造参数。
+        #    ** 会把返回的 dict 展开成 CMDM(...) 的关键字参数。
         model = CMDM(**get_model_args(args, data))
-        args.num_person = 1 # Attention here
+
+        # 4. 原始 batch 是双人数据，但 ccollate 已经拆成 actor 条件 cmotion 和 reactor 目标 motion。
+        #    diffusion 只负责给 reactor 这个单人目标动作加噪、去噪和算 loss。
+        args.num_person = 1
+
+    # 5. 创建高斯扩散过程；它定义训练时怎么加噪、怎么算 loss，以及采样时怎么去噪。
     diffusion = create_gaussian_diffusion(args)
+
+    # 6. 返回神经网络 model 和扩散过程 diffusion，后续会交给 TrainLoop 使用。
     return model, diffusion
 
 

--- a/utils/model_util.py
+++ b/utils/model_util.py
@@ -60,7 +60,7 @@ def get_model_args(args, data):
 
     if args.dataset == 'ntu':
         num_frames = 60
-    elif args.dataset == 'chi3d':
+    elif args.dataset in ['chi3d', 'interhuman']:
         num_frames = 150
 
     return {'modeltype': '', 'njoints': njoints, 'nfeats': nfeats, 'num_actions': num_actions, 'num_person': num_person, 

--- a/utils/parser_util.py
+++ b/utils/parser_util.py
@@ -189,6 +189,8 @@ def add_training_options(parser):
                        help="Save checkpoints and run evaluation each N steps")
     group.add_argument("--num_steps", default=600_000, type=int,
                        help="Training will stop after the specified number of steps.")
+    group.add_argument("--grad_accum_steps", default=1, type=int,
+                       help="Number of forward/backward passes before each optimizer step.")
     group.add_argument("--num_frames", default=60, type=int,
                        help="Limit for the maximal number of frames. In HumanML3D and KIT this field is ignored.")
     group.add_argument("--resume_checkpoint", default="", type=str,

--- a/utils/parser_util.py
+++ b/utils/parser_util.py
@@ -3,7 +3,8 @@ import argparse
 import os
 import json
 
-
+#  model000100000.pt -> 权重
+#  args.json         -> 构造同样模型所需的配置
 def parse_and_load_from_model(parser):
     # 从已训练模型同目录的 args.json 恢复参数。
     # 不要在命令行手动指定这些参数，因为后面会被 args.json 中的训练配置覆盖。
@@ -37,6 +38,7 @@ def parse_and_load_from_model(parser):
         args.guidance_param = 1
     return args
 
+#  用于“加载已有模型做条件生成”，保证模型结构一致，同时允许你换数据文件做生成。
 def parse_and_load_from_model_wo_data(parser):
     # 从已训练模型同目录的 args.json 恢复模型和扩散参数，但不覆盖数据集参数。
     # cgenerate 会显式传入数据相关参数，因此这里不加载 data options。

--- a/utils/parser_util.py
+++ b/utils/parser_util.py
@@ -5,8 +5,8 @@ import json
 
 
 def parse_and_load_from_model(parser):
-    # args according to the loaded model
-    # do not try to specify them from cmd line since they will be overwritten
+    # 从已训练模型同目录的 args.json 恢复参数。
+    # 不要在命令行手动指定这些参数，因为后面会被 args.json 中的训练配置覆盖。
     add_data_options(parser)
     add_model_options(parser)
     add_diffusion_options(parser)
@@ -15,7 +15,7 @@ def parse_and_load_from_model(parser):
     for group_name in ['dataset', 'model', 'diffusion']:
         args_to_overwrite += get_args_per_group_name(parser, args, group_name)
 
-    # load args from model
+    # 读取模型 checkpoint 所在目录下保存的训练参数。
     model_path = get_model_path_from_args()
     args_path = os.path.join(os.path.dirname(model_path), 'args.json')
     assert os.path.exists(args_path), 'Arguments json file was not found!'
@@ -26,7 +26,7 @@ def parse_and_load_from_model(parser):
         if a in model_args.keys():
             setattr(args, a, model_args[a])
 
-        elif 'cond_mode' in model_args: # backward compitability
+        elif 'cond_mode' in model_args: # 向后兼容旧版本 checkpoint
             unconstrained = (model_args['cond_mode'] == 'no_cond')
             setattr(args, 'unconstrained', unconstrained)
 
@@ -38,8 +38,8 @@ def parse_and_load_from_model(parser):
     return args
 
 def parse_and_load_from_model_wo_data(parser):
-    # args according to the loaded model
-    # do not try to specify them from cmd line since they will be overwritten
+    # 从已训练模型同目录的 args.json 恢复模型和扩散参数，但不覆盖数据集参数。
+    # cgenerate 会显式传入数据相关参数，因此这里不加载 data options。
     add_model_options(parser)
     add_diffusion_options(parser)
     args = parser.parse_args()
@@ -47,7 +47,7 @@ def parse_and_load_from_model_wo_data(parser):
     for group_name in ['model', 'diffusion']:
         args_to_overwrite += get_args_per_group_name(parser, args, group_name)
 
-    # load args from model
+    # 读取模型 checkpoint 所在目录下保存的训练参数。
     model_path = get_model_path_from_args()
     args_path = os.path.join(os.path.dirname(model_path), 'args.json')
     assert os.path.exists(args_path), 'Arguments json file was not found!'
@@ -58,7 +58,7 @@ def parse_and_load_from_model_wo_data(parser):
         if a in model_args.keys():
             setattr(args, a, model_args[a])
 
-        elif 'cond_mode' in model_args: # backward compitability
+        elif 'cond_mode' in model_args: # 向后兼容旧版本 checkpoint
             unconstrained = (model_args['cond_mode'] == 'no_cond')
             setattr(args, 'unconstrained', unconstrained)
 
@@ -88,6 +88,7 @@ def get_model_path_from_args():
 
 
 def add_base_options(parser):
+    # 基础参数：训练、采样、评估都会用到。
     group = parser.add_argument_group('base')
     group.add_argument("--cuda", default=True, type=bool, help="Use cuda device, otherwise use CPU.")
     group.add_argument("--device", default=0, type=int, help="Device id to use.")
@@ -98,6 +99,7 @@ def add_base_options(parser):
     group.add_argument("--timestep_respacing", default="", type=str, help="ddim timestep respacing.")
 
 def add_diffusion_options(parser):
+    # 高斯扩散过程参数：控制噪声日程、扩散步数和方差设置。
     group = parser.add_argument_group('diffusion')
     group.add_argument("--noise_schedule", default='cosine', choices=['linear', 'cosine'], type=str,
                        help="Noise schedule type")
@@ -107,6 +109,7 @@ def add_diffusion_options(parser):
 
 
 def add_model_options(parser):
+    # 模型参数：控制 MDM/CMDM 框架、Transformer/GRU/MLP 架构和动作专用 loss 权重。
     group = parser.add_argument_group('model')
     group.add_argument("--setting", default='mdm', choices=['mdm', 'cmdm'], type=str,
                        help="Training MDM or CMDM framework")
@@ -118,7 +121,7 @@ def add_model_options(parser):
                             " (in addition to cross-attention).")
     group.add_argument("--wo_pos_emb", action='store_true',
                        help="Add positional embedding or not.")
-    group.add_argument("--cm_mode", default='concat', # TODO
+    group.add_argument("--cm_mode", default='concat', # 待整理：concat2 当前没有完整实现路径
                        choices=['add', 'concat', 'concat2'], type=str,
                        help="Conditional modeling modes as reported in the paper.")
     group.add_argument("--layers", default=8, type=int,
@@ -141,8 +144,9 @@ def add_model_options(parser):
 
 
 def add_data_options(parser):
+    # 数据参数：决定读取哪个数据集、几个人、动作表示格式和人体模型类型。
     group = parser.add_argument_group('dataset')
-    group.add_argument("--dataset", default='humanml', choices=['humanml', 'kit', 'humanact12', 'uestc', 'ntu', 'chi3d', 'gta', 'sbu'], type=str,
+    group.add_argument("--dataset", default='humanml', choices=['humanml', 'kit', 'humanact12', 'uestc', 'ntu', 'chi3d', 'interhuman', 'gta', 'sbu'], type=str,
                        help="Dataset name (choose from list).")
     group.add_argument("--data_dir", default="", type=str,
                        help="If empty, will use defaults according to the specified dataset.")
@@ -153,8 +157,11 @@ def add_data_options(parser):
                        help="Use SMPL model or SMPl-X model.")
     group.add_argument("--vel_threshold", default=0.01, type=float, help="Threshold of the velocity.")
     group.add_argument("--shuffle", action='store_true', help="Shuffle the actor-reactor order during training.")
+    group.add_argument("--max_samples", default=-1, type=int,
+                       help="Limit dataset samples for smoke tests. -1 uses all samples.")
 
 def add_training_options(parser):
+    # 训练参数：控制保存目录、优化器、训练步数、日志、checkpoint 和训练中评估。
     group = parser.add_argument_group('training')
     group.add_argument("--save_dir", required=True, type=str,
                        help="Path to save checkpoints and results.")
@@ -178,7 +185,7 @@ def add_training_options(parser):
                        help="If -1, will use all samples in the specified split.")
     group.add_argument("--log_interval", default=1_000, type=int,
                        help="Log losses each N steps")
-    group.add_argument("--save_interval", default=10_000, type=int, # 50_000 original
+    group.add_argument("--save_interval", default=10_000, type=int, # 原始设置是 50_000
                        help="Save checkpoints and run evaluation each N steps")
     group.add_argument("--num_steps", default=600_000, type=int,
                        help="Training will stop after the specified number of steps.")
@@ -189,6 +196,7 @@ def add_training_options(parser):
 
 
 def add_sampling_options(parser):
+    # 采样参数：控制从哪个 checkpoint 生成、输出目录、样本数量和 CFG guidance 强度。
     group = parser.add_argument_group('sampling')
     group.add_argument("--model_path", required=True, type=str,
                        help="Path to model####.pt file to be sampled.")
@@ -205,6 +213,7 @@ def add_sampling_options(parser):
 
 
 def add_generate_options(parser):
+    # 生成参数：控制文本、动作类别或动作长度等生成条件。
     group = parser.add_argument_group('generate')
     group.add_argument("--motion_length", default=60, type=float,
                        help="The length of the sampled motion [in frames]. ")
@@ -221,6 +230,7 @@ def add_generate_options(parser):
 
 
 def add_edit_options(parser):
+    # 编辑参数：用于 motion editing，不参与普通训练入口。
     group = parser.add_argument_group('edit')
     group.add_argument("--edit_mode", default='in_between', choices=['in_between', 'upper_body'], type=str,
                        help="Defines which parts of the input motion will be edited.\n"
@@ -238,58 +248,101 @@ def add_edit_options(parser):
 
 
 def add_evaluation_options(parser):
+    # 评估参数：控制被评估模型、动作识别模型和评估模式。
     group = parser.add_argument_group('eval')
+
+    # 1. 指定要评估的 ReGenNet/CMDM 生成模型 checkpoint。
     group.add_argument("--model_path", required=True, type=str,
                        help="Path to model####.pt file to be sampled.")
+
+    # 2. 指定评估指标使用的动作识别模型 checkpoint；它不是待评估的生成模型。
     group.add_argument("--rec_model_path", required=True, type=str,
                        help="Path to model####.pt of the action recognition model.")
+
+    # 3. 选择评估规模，例如 debug 用于快速检查，full 用于完整指标。
     group.add_argument("--eval_mode", default='debug', type=str, help="Evaluation mode.")
+
+    # 4. 采样阶段的 classifier-free guidance 强度；训练 cond_mask_prob 为 0 时通常会被重置为 1。
     group.add_argument("--guidance_param", default=2.5, type=float,
                        help="For classifier-free sampling - specifies the s parameter, as defined in the paper.")
+
+    # 5. 控制评估时是否按自回归方式逐段/逐帧生成。
     group.add_argument("--auto_regressive", action='store_true',
                        help="Auto-regressive evaluation or not.")
 
 
 def train_args():
+    # 训练入口 train/train_mdm.py 只会使用下面这五组参数。
+    # 参数来源顺序就是：base -> dataset -> model -> diffusion -> training。
+
+    # 1. 创建训练专用 ArgumentParser。
     parser = ArgumentParser()
+
+    # 2. 注册通用参数，例如设备、随机种子、batch size 和 DDIM 设置。
     add_base_options(parser)
+
+    # 3. 注册数据参数，例如 dataset、data_path、num_person、pose_rep 和 body_model。
     add_data_options(parser)
+
+    # 4. 注册模型参数，例如 setting=cmdm、arch=online、cm_mode 和各类 loss 权重。
     add_model_options(parser)
+
+    # 5. 注册扩散过程参数，例如 noise_schedule、diffusion_steps 和 sigma_small。
     add_diffusion_options(parser)
+
+    # 6. 注册训练参数，例如 save_dir、lr、num_steps、日志和 checkpoint 间隔。
     add_training_options(parser)
+
+    # 7. 解析命令行参数并返回给 train/train_mdm.py。
     return parser.parse_args()
 
 
 def generate_args():
+    # 1. 创建普通采样入口的参数解析器，主要服务 sample/generate.py。
     parser = ArgumentParser()
-    # args specified by the user: (all other will be loaded from the model)
+
+    # 2. 用户只需要指定基础、采样和生成条件；模型/数据/扩散参数从 args.json 恢复。
     add_base_options(parser)
     add_sampling_options(parser)
     add_generate_options(parser)
+
+    # 3. 从 checkpoint 同目录 args.json 加载训练时的数据、模型和扩散配置。
     return parse_and_load_from_model(parser)
 
 def cgenerate_args():
+    # 1. 创建条件生成入口的参数解析器，主要服务 sample/cgenerate.py。
     parser = ArgumentParser()
-    # args specified by the user: (all other will be loaded from the model)
+
+    # 2. cgenerate 需要显式传入数据参数，用来构造 actor motion 条件数据加载器。
     add_base_options(parser)
     add_data_options(parser)
     add_sampling_options(parser)
     add_generate_options(parser)
+
+    # 3. 只从 args.json 恢复模型和扩散配置，保留命令行传入的数据参数。
     return parse_and_load_from_model_wo_data(parser)
 
 
 def edit_args():
+    # 1. 创建 motion editing 入口的参数解析器。
     parser = ArgumentParser()
-    # args specified by the user: (all other will be loaded from the model)
+
+    # 2. 编辑任务只需要基础参数、采样 checkpoint 和编辑区域/文本条件。
     add_base_options(parser)
     add_sampling_options(parser)
     add_edit_options(parser)
+
+    # 3. 从 checkpoint 同目录 args.json 恢复训练时的数据、模型和扩散配置。
     return parse_and_load_from_model(parser)
 
 
 def evaluation_parser():
+    # 1. 创建评估入口的参数解析器，主要服务 eval/eval_cmdm.py。
     parser = ArgumentParser()
-    # args specified by the user: (all other will be loaded from the model)
+
+    # 2. 评估时命令行只指定设备、待评估模型、识别模型和评估模式。
     add_base_options(parser)
     add_evaluation_options(parser)
+
+    # 3. 从待评估模型同目录 args.json 恢复训练配置，保证评估模型结构一致。
     return parse_and_load_from_model(parser)


### PR DESCRIPTION
## Summary

- Add InterHuman forecasting dataset protocol for 150-frame windows with 30 observed frames and 120 future frames.
- Add active-vector extract/restore utilities and train-only forecasting normalizer.
- Add `eval.eval_forecasting --mode dataset_smoke` for P1 validation.
- Record forecasting design, P1 plan, and P1 result context under `docs/ai/context/`.

## Validation

```bash
micromamba run -p /home/rpartx3080/.local/micromamba/envs/regennet python -m eval.eval_forecasting \
  --mode dataset_smoke \
  --dataset interhuman \
  --data_path dataset/interhuman/smpl/conditioned \
  --window_len 150 \
  --obs_len 30 \
  --pred_len 120 \
  --batch_size 4 \
  --num_workers 0 \
  --save_dir save/forecasting/interhuman/p1_dataset_smoke
```

Passed locally:

- train/val/test usable samples: `2910/226/508`
- batch shapes: `obs=[4,30,2,147]`, `target=[4,120,2,147]`
- active roundtrip max error: `0.0`
- normalize/denormalize max error: `1.1920928955078125e-07`

## Scope note

This branch was created from the current local work state, so the PR includes earlier InterHuman H5 / training-loop commits that are not currently in `main`, plus the new forecasting P1 commit.
